### PR TITLE
Plan predictive typing trust roadmap and ship first symbol-flow slice

### DIFF
--- a/.project/projects/predictive-typing-quality-trust/decisions.md
+++ b/.project/projects/predictive-typing-quality-trust/decisions.md
@@ -1,0 +1,12 @@
+# Decisions
+
+Track key project decisions with context and rationale.
+
+## 2026-03-28
+
+- Create a fresh project `predictive-typing-quality-trust` instead of editing `typing-speed-core` in place because the existing scope already contains execution history, validation evidence, and partially completed tasks.
+- Keep this project focused on predictive-typing planning, evaluation, and rollout governance rather than direct implementation work.
+- Treat the inaccessible ChatGPT research page as a citation gap, not a blocker to setting up the planning structure and Linear objects.
+- Use Linear raw payloads when the generated CLI wrapper omits supported fields such as project team or issue project assignment.
+- Complete milestone and issue creation through the Linear GraphQL API because the generated CLI advertised `create-milestone` and `create-issue` commands that returned `Tool create_milestone not found` and `Tool create_issue not found` in this environment.
+- Record the known path-leakage validation failure in `typing-speed-core` separately so it is not misattributed to this project.

--- a/.project/projects/predictive-typing-quality-trust/decisions.md
+++ b/.project/projects/predictive-typing-quality-trust/decisions.md
@@ -10,3 +10,4 @@ Track key project decisions with context and rationale.
 - Use Linear raw payloads when the generated CLI wrapper omits supported fields such as project team or issue project assignment.
 - Complete milestone and issue creation through the Linear GraphQL API because the generated CLI advertised `create-milestone` and `create-issue` commands that returned `Tool create_milestone not found` and `Tool create_issue not found` in this environment.
 - Record the known path-leakage validation failure in `typing-speed-core` separately so it is not misattributed to this project.
+- Add primary-source citations directly into the planning docs where they sharpen concrete architecture choices: use the Gboard decoder and neural-search-space papers to justify the hybrid stack assumption, and use the Google / SwiftKey / Apple privacy papers to justify keeping personalization and privacy constraints coupled from the start.

--- a/.project/projects/predictive-typing-quality-trust/plan.md
+++ b/.project/projects/predictive-typing-quality-trust/plan.md
@@ -3,7 +3,7 @@ name: Predictive Typing Quality & Trust
 status: planned
 lead: ownkey-keyboard-team
 created: 2026-03-28T11:19:17Z
-updated: 2026-03-28T11:35:00Z
+updated: 2026-03-28T13:11:21Z
 linear_project_id: 8e478486-d8e6-44e4-bac7-5a55c6bbdba8
 ---
 
@@ -11,13 +11,13 @@ linear_project_id: 8e478486-d8e6-44e4-bac7-5a55c6bbdba8
 
 ## Architecture Decisions
 - Keep this project planning-focused and separate from `typing-speed-core`, which already contains implementation-era task history.
-- Plan around a hybrid keyboard stack: decoder and candidate generation, language-model ranking, multilingual routing, and personalization are separate concerns that must be tuned together.
+- Plan around a hybrid keyboard stack: decoder and candidate generation, language-model ranking, multilingual routing, and personalization are separate concerns that must be tuned together. This matches public Gboard evidence across both FST decoder work and newer neural search-space work rather than a single-model story. Sources: [1704.03987](https://arxiv.org/abs/1704.03987), [2410.15575](https://arxiv.org/abs/2410.15575).
 - Treat latency, ranking quality, and trust errors as separate decision axes, not one blended score.
 - Use trust-first defaults: prediction help should degrade gracefully instead of correcting aggressively under uncertainty.
 - Assume compact methods such as finite-state search or n-gram components may still be the right fit for some low-latency layers, even if richer neural models are used elsewhere.
 - Treat GRU/RNN-class and lightweight transformer options as candidate ranking layers, not automatic replacements for the whole stack.
 - Design multilingual and personalization policies together so language-mixing does not poison learned vocabulary.
-- Keep future federated-learning and differential-privacy options compatible with the planning baseline, even if no training approach is selected yet.
+- Keep future federated-learning and differential-privacy options compatible with the planning baseline, even if no training approach is selected yet. Sources: [Gboard FL keyboard prediction](https://research.google/pubs/federated-learning-for-mobile-keyboard-prediction-2/), [Gboard FL + DP](https://arxiv.org/abs/2305.18465), [SwiftKey DP transformer](https://arxiv.org/abs/2505.05648), [Apple private personalization](https://machinelearning.apple.com/research/private-and-personalized).
 - Make reversibility a first-class product constraint through undo, suppression, and explainable tuning surfaces.
 
 ## Workstream Design

--- a/.project/projects/predictive-typing-quality-trust/plan.md
+++ b/.project/projects/predictive-typing-quality-trust/plan.md
@@ -1,0 +1,63 @@
+---
+name: Predictive Typing Quality & Trust
+status: planned
+lead: ownkey-keyboard-team
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:35:00Z
+linear_project_id: 8e478486-d8e6-44e4-bac7-5a55c6bbdba8
+---
+
+# Delivery Plan: Predictive Typing Quality & Trust
+
+## Architecture Decisions
+- Keep this project planning-focused and separate from `typing-speed-core`, which already contains implementation-era task history.
+- Plan around a hybrid keyboard stack: decoder and candidate generation, language-model ranking, multilingual routing, and personalization are separate concerns that must be tuned together.
+- Treat latency, ranking quality, and trust errors as separate decision axes, not one blended score.
+- Use trust-first defaults: prediction help should degrade gracefully instead of correcting aggressively under uncertainty.
+- Assume compact methods such as finite-state search or n-gram components may still be the right fit for some low-latency layers, even if richer neural models are used elsewhere.
+- Treat GRU/RNN-class and lightweight transformer options as candidate ranking layers, not automatic replacements for the whole stack.
+- Design multilingual and personalization policies together so language-mixing does not poison learned vocabulary.
+- Keep future federated-learning and differential-privacy options compatible with the planning baseline, even if no training approach is selected yet.
+- Make reversibility a first-class product constraint through undo, suppression, and explainable tuning surfaces.
+
+## Workstream Design
+- **WS-1 Benchmark and Latency Budget**: define corpus coverage, measurement rules, architecture-comparison criteria, and target envelopes.
+- **WS-2 Trust-first Correction UX**: define when OwnKey should predict, autocorrect, back off, or help users recover.
+- **WS-3 Multilingual Personalization Strategy**: define EN/NL mixing, dictionary boundaries, privacy guardrails, and learning behavior.
+- **WS-4 Rollout Readiness and KPI Governance**: convert planning into milestones, issue sequencing, and go/no-go gates.
+
+## Milestone Strategy
+1. **M1 Benchmark Baseline**: lock corpus coverage, KPI definitions, architecture comparison rules, and latency budget.
+2. **M2 Trust Policy Definition**: finalize autocorrect, undo, suppression, and tuning rules.
+3. **M3 Multilingual Personalization Plan**: finalize mixed-language behavior, user-vocabulary learning, and privacy boundaries.
+4. **M4 Delivery Readiness**: convert the planning package into an implementation-ready roadmap with acceptance thresholds.
+
+## Rollout Strategy
+- Use this project as the planning and alignment layer before adding or reshaping implementation tickets.
+- Validate proposed changes first against benchmark and trust criteria, then stage into internal, beta, and broader rollout decisions.
+- Hold rollout on any milestone that improves speed while materially degrading user trust signals.
+- Treat locale strategy as configurable: if EN, NL, and mixed-language flows need different model mixes or thresholds, preserve that option instead of forcing one compromise setting.
+
+## Test Strategy
+- Review all planning outputs against handbook contract requirements and path-privacy constraints.
+- Validate benchmark, KPI, and rollout rules for traceability back to one or more user risks.
+- Compare candidate stack choices against the research-backed method families: decoder or finite-state search, compact LM layers, richer neural ranking, and personalization strategy.
+- Smoke-check Linear sync by ensuring project, milestones, and initial issues map cleanly back into local frontmatter and registry state.
+- Treat repository-wide path leakage in older project artifacts as a separate pre-existing validation issue, not a failure of this new scope.
+
+## Rollback Strategy
+- If Linear sync becomes inconsistent, keep local Delano artifacts authoritative and document the manual cleanup required.
+- If milestone boundaries prove too overlapping, collapse them locally before any execution work starts.
+- If planning scope drifts into implementation details that duplicate `typing-speed-core`, stop and split the overlap into explicit follow-up notes.
+- If a proposed model direction cannot defend its latency, trust, or privacy trade-offs, fall back to the simpler viable layer instead of forcing architectural novelty.
+
+## Linear Synchronization
+- Linear project: `8e478486-d8e6-44e4-bac7-5a55c6bbdba8`
+- Project URL: https://linear.app/bartvandermeeren/project/predictive-typing-quality-and-trust-774d3d5b8a58
+- Team: `BAR` (`Bartvandermeeren`)
+- Milestones created:
+  - `M1 Benchmark Baseline`: `90330589-1cb2-476e-84e1-2892baa0140e`
+  - `M2 Trust Policy Definition`: `abc7199a-9a91-4125-b49e-ed15f90646c8`
+  - `M3 Multilingual Personalization Plan`: `2897763b-449d-45bc-adae-4c292f2fe0c9`
+  - `M4 Delivery Readiness`: `402d61ef-4959-4668-aaa1-b618dd8cdd1f`
+- Workstream label fallback was added to preserve workstream grouping because the generated Linear CLI advertised `create-milestone` and `create-issue` wrappers that were not actually backed by available MCP tools in this environment. Project and issue creation were completed via direct Linear GraphQL mutations using the existing API key.

--- a/.project/projects/predictive-typing-quality-trust/spec.md
+++ b/.project/projects/predictive-typing-quality-trust/spec.md
@@ -1,0 +1,86 @@
+---
+name: Predictive Typing Quality & Trust
+slug: predictive-typing-quality-trust
+owner: ownkey-keyboard-team
+status: draft
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:35:00Z
+outcome: Define a trust-first predictive typing roadmap that can raise top-3 suggestion acceptance by 15%, hold suggestion latency under 50 ms p95, and reduce false autocorrect pain by 30% across EN, NL, and mixed-language flows.
+---
+
+# Spec: Predictive Typing Quality & Trust
+
+## Executive Summary
+OwnKey needs a predictive typing roadmap that optimizes for both speed and trust. The strongest public evidence from modern keyboards suggests that good products do not rely on one magic next-word model. They use a hybrid prediction stack: decoder logic for literal input and correction, compact language-model components for speed, richer neural components for context, and personalization layers that respect privacy boundaries. This project defines the planning baseline, evaluation model, and rollout shape needed before a larger implementation push.
+
+## Problem and Users
+OwnKey's most valuable typing moments are also the easiest to break. Fast typers lose rhythm when predictions lag. Multilingual users stop trusting the bar when language routing collapses inside one sentence. Autocorrect becomes harmful when it is technically accurate too often in the wrong moments, such as names, jargon, or code-switching. Mobile keyboards also do more than next-word prediction. They combine literal typing, correction, completion, and sometimes swipe-style decoding under strict on-device latency constraints.
+
+Primary users:
+- Fast typers who care more about uninterrupted flow than aggressive automation
+- EN/NL multilingual users who switch language mid-sentence
+- Users who expect chat, notes, and email contexts to behave differently
+- Users who want personalization benefits without losing control or privacy
+
+## Scope and Non-Goals
+### In Scope
+- Prediction quality and trust planning for top-3 suggestions and autocorrect
+- Candidate-generation and decoder-layer requirements for typed input, correction, and completion behavior
+- Latency budgets for keystroke-to-suggestion updates and keyboard warm start
+- Mixed-language EN/NL ranking, fallback, and correction behavior
+- Personalization rules for user vocabulary promotion and suppression
+- Recovery patterns such as undo, backspace restore, never-correct, and tuning controls
+- KPI definitions, benchmark corpus requirements, and rollout acceptance thresholds
+- Mapping the planning scope into Delano contracts and Linear execution objects
+
+### Non-Goals
+- Training or shipping a new cloud-hosted language model in this planning pass
+- Voice dictation or speech-to-text roadmap work
+- Broad visual redesign unrelated to predictive typing trust or clarity
+- Direct ingestion of the inaccessible shared ChatGPT research page without a user-provided source list
+
+## Functional Requirements
+1. Define a benchmark corpus strategy that covers EN, NL, and mixed-language typing scenarios, including names, slang, code-switching, and domain terms.
+2. Define a reference prediction stack that separates decoder/candidate generation, ranking language model behavior, and personalization layers instead of assuming one model can own the full problem.
+3. Compare likely method families for each layer, including n-gram components, finite-state or decoder-based search, RNN/GRU-class models, and lightweight transformer-style options where relevant.
+4. Define a latency envelope that targets visible suggestion updates under 50 ms p95 and keyboard first-input readiness under 200 ms.
+5. Define a trust-first autocorrect policy with confidence gating, reversible actions, and clear suppression rules.
+6. Define multilingual routing rules that preserve prediction quality without requiring manual language switching.
+7. Define personalization rules that promote useful terms quickly while avoiding noisy or temporary overfitting.
+8. Define privacy-preserving adaptation options, including on-device learning boundaries and compatibility with future federated-learning or differential-privacy approaches.
+9. Define user-facing controls for tuning aggressiveness, never-correct behavior, and recovery flows.
+10. Define measurable success criteria that can be used as rollout gates for internal, beta, and broader release stages.
+11. Define an execution-ready backlog and milestone map that can be synchronized to Linear.
+
+## Non-Functional Requirements
+- All planning artifacts must use UTC timestamps and avoid absolute local path leakage.
+- Metrics and evidence definitions must remain privacy-safe and avoid raw typed-content logging.
+- Planning outputs must be specific enough to drive implementation without requiring a second PRD rewrite.
+- Quality gates must distinguish latency regressions from trust regressions instead of collapsing both into one KPI.
+- The architecture plan must respect on-device memory and latency limits before favoring richer model families.
+- Locale strategy must allow different model mixes per language or market if one global route is not defensible.
+
+## Success Metrics
+- Top-3 suggestion acceptance: +15% versus current baseline in target scenarios
+- Suggestion latency: < 50 ms p95 in representative benchmark runs
+- Keyboard warm start plus first useful suggestion: < 200 ms perceived response target
+- False autocorrect pain rate: -30% versus baseline
+- Mixed-language relevance score: improved versus baseline on EN/NL code-switch corpus
+- Personalization time-to-benefit: repeated user terms surface within 1-3 accepted exposures without noisy-term inflation
+- Architecture decision clarity: every major predictive-typing layer has an explicit chosen method or ruled-out option with rationale
+
+## Risks and Assumptions
+- The shared research page is currently unreadable in this run, so source-specific citations remain a follow-up item even though the local Obsidian note now provides the primary research basis.
+- Existing `typing-speed-core` artifacts already cover overlapping implementation territory, so scope boundaries must stay explicit.
+- Benchmark quality will be weak if the corpus underrepresents multilingual switching, names, app-context variance, or correction-heavy scenarios.
+- A single-model mindset can oversimplify the real keyboard problem and produce the wrong roadmap.
+- Aggressive personalization can improve acceptance while silently damaging trust if reversibility is weak.
+- Latency wins that degrade ranking quality are not acceptable and must be measured separately.
+
+## Dependencies
+- Delano handbook contracts in `HANDBOOK.md`
+- Existing product context in `.project/context/`
+- Current typing-related implementation history in `.project/projects/typing-speed-core/`
+- Research basis in Bart's Obsidian note `Keyboard prediction methodes.md`
+- Linear workspace access through the local `linear-mcp-cli` and direct GraphQL fallback
+- User follow-up for any source-level citations that need to be reconstructed beyond the local research note

--- a/.project/projects/predictive-typing-quality-trust/spec.md
+++ b/.project/projects/predictive-typing-quality-trust/spec.md
@@ -4,7 +4,7 @@ slug: predictive-typing-quality-trust
 owner: ownkey-keyboard-team
 status: draft
 created: 2026-03-28T11:19:17Z
-updated: 2026-03-28T11:35:00Z
+updated: 2026-03-28T13:11:21Z
 outcome: Define a trust-first predictive typing roadmap that can raise top-3 suggestion acceptance by 15%, hold suggestion latency under 50 ms p95, and reduce false autocorrect pain by 30% across EN, NL, and mixed-language flows.
 ---
 
@@ -12,6 +12,11 @@ outcome: Define a trust-first predictive typing roadmap that can raise top-3 sug
 
 ## Executive Summary
 OwnKey needs a predictive typing roadmap that optimizes for both speed and trust. The strongest public evidence from modern keyboards suggests that good products do not rely on one magic next-word model. They use a hybrid prediction stack: decoder logic for literal input and correction, compact language-model components for speed, richer neural components for context, and personalization layers that respect privacy boundaries. This project defines the planning baseline, evaluation model, and rollout shape needed before a larger implementation push.
+
+### Research anchors
+- Google's earlier Gboard decoder work describes a weighted finite-state decoding stack for mobile keyboard correction and prediction, which supports keeping decoder or candidate-generation responsibilities separate from the ranking model instead of assuming one end-to-end model should do everything. Source: [Gboard decoder / FST search](https://arxiv.org/abs/1704.03987).
+- Google's newer Gboard search-space work reinforces the same layered idea for neural systems: candidate search space quality matters independently from downstream ranking quality. Source: [Gboard neural search space](https://arxiv.org/abs/2410.15575).
+- Keyboard personalization and privacy are not optional add-ons. Public Gboard, SwiftKey, and Apple work all point toward on-device or privacy-preserving adaptation as the practical direction for production keyboards. Sources: [Gboard federated keyboard prediction](https://research.google/pubs/federated-learning-for-mobile-keyboard-prediction-2/), [Gboard federated learning + differential privacy](https://arxiv.org/abs/2305.18465), [SwiftKey differentially private transformer](https://arxiv.org/abs/2505.05648), and [Apple private and personalized frequency estimation](https://machinelearning.apple.com/research/private-and-personalized).
 
 ## Problem and Users
 OwnKey's most valuable typing moments are also the easiest to break. Fast typers lose rhythm when predictions lag. Multilingual users stop trusting the bar when language routing collapses inside one sentence. Autocorrect becomes harmful when it is technically accurate too often in the wrong moments, such as names, jargon, or code-switching. Mobile keyboards also do more than next-word prediction. They combine literal typing, correction, completion, and sometimes swipe-style decoding under strict on-device latency constraints.

--- a/.project/projects/predictive-typing-quality-trust/tasks/T-001-define-benchmark-corpus-and-measurement-protocol.md
+++ b/.project/projects/predictive-typing-quality-trust/tasks/T-001-define-benchmark-corpus-and-measurement-protocol.md
@@ -1,0 +1,37 @@
+---
+id: T-001
+name: Define benchmark corpus and measurement protocol
+status: ready
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:35:00Z
+linear_issue_id: e6a72d3d-5fa4-43d6-8f02-e92b70d93efe
+github_issue:
+github_pr:
+depends_on: []
+conflicts_with: []
+parallel: true
+priority: high
+estimate: M
+---
+
+# Task: Define benchmark corpus and measurement protocol
+
+## Description
+Specify the scenario set, input categories, and scoring rules used to evaluate predictive typing quality across EN, NL, and mixed-language typing, including completion, autocorrect, and decoder-heavy correction cases.
+
+## Acceptance Criteria
+- [ ] Corpus categories cover monolingual, code-switching, names, slang, domain terms, and correction-heavy cases.
+- [ ] Scoring rules distinguish latency, ranking quality, trust failures, and decoder-level recovery quality.
+
+## Technical Notes
+This task creates the evaluation backbone for every later product decision and must compare the real keyboard stack, not only next-word prediction in isolation.
+
+## Definition of Done
+- [ ] Implementation complete
+- [ ] Tests pass
+- [ ] Review complete
+- [ ] Docs updated
+
+## Evidence Log
+- 2026-03-28: Synced to Linear as `BAR-68` (https://linear.app/bartvandermeeren/issue/BAR-68/t-001-define-benchmark-corpus-and-measurement-protocol).
+- 2026-03-28: Task created during predictive typing planning pass.

--- a/.project/projects/predictive-typing-quality-trust/tasks/T-001-define-benchmark-corpus-and-measurement-protocol.md
+++ b/.project/projects/predictive-typing-quality-trust/tasks/T-001-define-benchmark-corpus-and-measurement-protocol.md
@@ -3,7 +3,7 @@ id: T-001
 name: Define benchmark corpus and measurement protocol
 status: ready
 created: 2026-03-28T11:19:17Z
-updated: 2026-03-28T11:35:00Z
+updated: 2026-03-28T13:11:21Z
 linear_issue_id: e6a72d3d-5fa4-43d6-8f02-e92b70d93efe
 github_issue:
 github_pr:
@@ -24,7 +24,7 @@ Specify the scenario set, input categories, and scoring rules used to evaluate p
 - [ ] Scoring rules distinguish latency, ranking quality, trust failures, and decoder-level recovery quality.
 
 ## Technical Notes
-This task creates the evaluation backbone for every later product decision and must compare the real keyboard stack, not only next-word prediction in isolation.
+This task creates the evaluation backbone for every later product decision and must compare the real keyboard stack, not only next-word prediction in isolation. Benchmark scenarios should explicitly cover decoder-heavy correction and candidate-generation behavior because public Gboard work frames those layers as first-class system components, not background plumbing. Sources: [1704.03987](https://arxiv.org/abs/1704.03987), [2410.15575](https://arxiv.org/abs/2410.15575).
 
 ## Definition of Done
 - [ ] Implementation complete

--- a/.project/projects/predictive-typing-quality-trust/tasks/T-002-set-latency-budget-and-warm-start-acceptance-bar.md
+++ b/.project/projects/predictive-typing-quality-trust/tasks/T-002-set-latency-budget-and-warm-start-acceptance-bar.md
@@ -3,7 +3,7 @@ id: T-002
 name: Set latency budget and warm-start acceptance bar
 status: ready
 created: 2026-03-28T11:19:17Z
-updated: 2026-03-28T11:35:00Z
+updated: 2026-03-28T13:11:21Z
 linear_issue_id: 7153d4f5-e877-4d45-8b22-78421c1381b4
 github_issue:
 github_pr:
@@ -25,7 +25,7 @@ Define the performance envelope for suggestion refresh, keyboard open, first-use
 - [ ] The latency plan states which responsibilities belong in decoder or compact-model layers versus richer neural layers.
 
 ## Technical Notes
-Use representative device classes instead of one desktop-like benchmark only, and assume some stack layers may need n-gram or finite-state simplicity for speed.
+Use representative device classes instead of one desktop-like benchmark only, and assume some stack layers may need n-gram or finite-state simplicity for speed. The public Gboard decoder and search-space work are the main anchors for keeping low-latency candidate-generation layers lightweight even when downstream ranking grows more neural. Sources: [1704.03987](https://arxiv.org/abs/1704.03987), [2410.15575](https://arxiv.org/abs/2410.15575).
 
 ## Definition of Done
 - [ ] Implementation complete

--- a/.project/projects/predictive-typing-quality-trust/tasks/T-002-set-latency-budget-and-warm-start-acceptance-bar.md
+++ b/.project/projects/predictive-typing-quality-trust/tasks/T-002-set-latency-budget-and-warm-start-acceptance-bar.md
@@ -1,0 +1,38 @@
+---
+id: T-002
+name: Set latency budget and warm-start acceptance bar
+status: ready
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:35:00Z
+linear_issue_id: 7153d4f5-e877-4d45-8b22-78421c1381b4
+github_issue:
+github_pr:
+depends_on: [T-001]
+conflicts_with: []
+parallel: false
+priority: high
+estimate: S
+---
+
+# Task: Set latency budget and warm-start acceptance bar
+
+## Description
+Define the performance envelope for suggestion refresh, keyboard open, first-useful-suggestion readiness, and the fast-path layers that must stay lightweight in the predictive stack.
+
+## Acceptance Criteria
+- [ ] p95 suggestion and warm-start targets are explicit and measurable.
+- [ ] The plan defines how to detect latency regressions separately from ranking-quality regressions.
+- [ ] The latency plan states which responsibilities belong in decoder or compact-model layers versus richer neural layers.
+
+## Technical Notes
+Use representative device classes instead of one desktop-like benchmark only, and assume some stack layers may need n-gram or finite-state simplicity for speed.
+
+## Definition of Done
+- [ ] Implementation complete
+- [ ] Tests pass
+- [ ] Review complete
+- [ ] Docs updated
+
+## Evidence Log
+- 2026-03-28: Synced to Linear as `BAR-69` (https://linear.app/bartvandermeeren/issue/BAR-69/t-002-set-latency-budget-and-warm-start-acceptance-bar).
+- 2026-03-28: Task created during predictive typing planning pass.

--- a/.project/projects/predictive-typing-quality-trust/tasks/T-003-specify-trust-first-autocorrect-policy-and-recovery-flows.md
+++ b/.project/projects/predictive-typing-quality-trust/tasks/T-003-specify-trust-first-autocorrect-policy-and-recovery-flows.md
@@ -1,0 +1,38 @@
+---
+id: T-003
+name: Specify trust-first autocorrect policy and recovery flows
+status: ready
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:35:00Z
+linear_issue_id: fbc0bfe5-f4e7-486b-9db6-46bfeb3f1372
+github_issue:
+github_pr:
+depends_on: [T-001]
+conflicts_with: []
+parallel: true
+priority: high
+estimate: M
+---
+
+# Task: Specify trust-first autocorrect policy and recovery flows
+
+## Description
+Define confidence thresholds, suppression rules, undo behavior, and backspace recovery for predictive typing corrections across literal typing, completion, and autocorrect flows.
+
+## Acceptance Criteria
+- [ ] The policy defines when OwnKey should autocorrect, suggest only, or do nothing.
+- [ ] Recovery paths cover undo, backspace restore, and never-correct suppression.
+- [ ] The policy distinguishes decoder certainty from language-model certainty when deciding to auto-apply a correction.
+
+## Technical Notes
+Trust failures should be treated as first-class product defects, not only accuracy misses, especially when decoder behavior and language modeling disagree.
+
+## Definition of Done
+- [ ] Implementation complete
+- [ ] Tests pass
+- [ ] Review complete
+- [ ] Docs updated
+
+## Evidence Log
+- 2026-03-28: Synced to Linear as `BAR-70` (https://linear.app/bartvandermeeren/issue/BAR-70/t-003-specify-trust-first-autocorrect-policy-and-recovery-flows).
+- 2026-03-28: Task created during predictive typing planning pass.

--- a/.project/projects/predictive-typing-quality-trust/tasks/T-004-define-multilingual-routing-and-code-switching-rules.md
+++ b/.project/projects/predictive-typing-quality-trust/tasks/T-004-define-multilingual-routing-and-code-switching-rules.md
@@ -1,0 +1,38 @@
+---
+id: T-004
+name: Define multilingual routing and code-switching rules
+status: ready
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:35:00Z
+linear_issue_id: 5768e53f-4136-4e2f-9c50-a1b77db63c1e
+github_issue:
+github_pr:
+depends_on: [T-001]
+conflicts_with: []
+parallel: true
+priority: high
+estimate: M
+---
+
+# Task: Define multilingual routing and code-switching rules
+
+## Description
+Specify how EN, NL, and mixed-language input should be ranked, corrected, and recovered without manual language switching, while leaving room for locale-specific model choices.
+
+## Acceptance Criteria
+- [ ] The plan covers sentence-level code-switching, name-heavy input, and app-context variance.
+- [ ] Fallback behavior is defined for uncertain language classification.
+- [ ] The routing plan states whether different locales or markets may need different model mixes or thresholds.
+
+## Technical Notes
+Prioritize stable user trust over aggressive language guessing, and do not assume a single global route fits every locale equally well.
+
+## Definition of Done
+- [ ] Implementation complete
+- [ ] Tests pass
+- [ ] Review complete
+- [ ] Docs updated
+
+## Evidence Log
+- 2026-03-28: Synced to Linear as `BAR-71` (https://linear.app/bartvandermeeren/issue/BAR-71/t-004-define-multilingual-routing-and-code-switching-rules).
+- 2026-03-28: Task created during predictive typing planning pass.

--- a/.project/projects/predictive-typing-quality-trust/tasks/T-005-define-personalization-learning-policy-and-privacy-guardrails.md
+++ b/.project/projects/predictive-typing-quality-trust/tasks/T-005-define-personalization-learning-policy-and-privacy-guardrails.md
@@ -1,0 +1,38 @@
+---
+id: T-005
+name: Define personalization learning policy and privacy guardrails
+status: ready
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:35:00Z
+linear_issue_id: a2397a74-b122-46cc-bb62-a33a11676f4d
+github_issue:
+github_pr:
+depends_on: [T-001, T-004]
+conflicts_with: []
+parallel: false
+priority: high
+estimate: M
+---
+
+# Task: Define personalization learning policy and privacy guardrails
+
+## Description
+Define when user terms should be learned, when they should decay or be suppressed, and which privacy boundaries must never be crossed in a future on-device or federated-learning setup.
+
+## Acceptance Criteria
+- [ ] Promotion, decay, and suppression rules are explicit.
+- [ ] The policy forbids raw typed-content logging and clarifies on-device learning boundaries.
+- [ ] The plan states how future federated-learning or differential-privacy approaches could fit without weakening user trust.
+
+## Technical Notes
+Learning speed should optimize for trust and usefulness, not vocabulary volume. The note basis suggests personalization quality is a major product differentiator, but only when privacy guarantees stay credible.
+
+## Definition of Done
+- [ ] Implementation complete
+- [ ] Tests pass
+- [ ] Review complete
+- [ ] Docs updated
+
+## Evidence Log
+- 2026-03-28: Synced to Linear as `BAR-72` (https://linear.app/bartvandermeeren/issue/BAR-72/t-005-define-personalization-learning-policy-and-privacy-guardrails).
+- 2026-03-28: Task created during predictive typing planning pass.

--- a/.project/projects/predictive-typing-quality-trust/tasks/T-006-define-tuning-surface-and-user-facing-explainability.md
+++ b/.project/projects/predictive-typing-quality-trust/tasks/T-006-define-tuning-surface-and-user-facing-explainability.md
@@ -1,0 +1,38 @@
+---
+id: T-006
+name: Define tuning surface and user-facing explainability
+status: ready
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:35:00Z
+linear_issue_id: 0268e1e8-49ef-44b7-87d1-c478a53826eb
+github_issue:
+github_pr:
+depends_on: [T-003, T-005]
+conflicts_with: []
+parallel: false
+priority: medium
+estimate: S
+---
+
+# Task: Define tuning surface and user-facing explainability
+
+## Description
+Specify the minimum settings, copy, and explainability needed so users can tune predictive typing, personalization, and autocorrect behavior without confusion.
+
+## Acceptance Criteria
+- [ ] The proposal defines the minimum viable tuning controls and when they should appear.
+- [ ] User-facing wording is clear about speed-versus-control trade-offs.
+- [ ] Privacy and personalization controls are understandable without exposing model jargon.
+
+## Technical Notes
+Avoid feature sprawl. Preference surfaces should clarify, not overwhelm, especially when personalization and trust controls intersect.
+
+## Definition of Done
+- [ ] Implementation complete
+- [ ] Tests pass
+- [ ] Review complete
+- [ ] Docs updated
+
+## Evidence Log
+- 2026-03-28: Synced to Linear as `BAR-73` (https://linear.app/bartvandermeeren/issue/BAR-73/t-006-define-tuning-surface-and-user-facing-explainability).
+- 2026-03-28: Task created during predictive typing planning pass.

--- a/.project/projects/predictive-typing-quality-trust/tasks/T-007-map-planning-scope-to-milestones-and-linear-execution.md
+++ b/.project/projects/predictive-typing-quality-trust/tasks/T-007-map-planning-scope-to-milestones-and-linear-execution.md
@@ -1,0 +1,38 @@
+---
+id: T-007
+name: Map planning scope to milestones and Linear execution
+status: ready
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:35:00Z
+linear_issue_id: 2ecd539a-bffb-426a-8a83-72296f2df395
+github_issue:
+github_pr:
+depends_on: [T-001, T-003, T-004, T-005]
+conflicts_with: []
+parallel: false
+priority: high
+estimate: S
+---
+
+# Task: Map planning scope to milestones and Linear execution
+
+## Description
+Convert the planning package into milestone-aligned tracker objects, issue sequencing, registry updates, and architecture-decision visibility in Linear.
+
+## Acceptance Criteria
+- [ ] Linear project, milestones, and initial issues map back to local Delano artifacts.
+- [ ] Method-family decisions and architecture assumptions are visible in the planning copy.
+- [ ] Any sync gaps are documented with exact manual follow-up steps.
+
+## Technical Notes
+Local Delano contracts remain authoritative if tracker fields or schemas drift. In this run, direct GraphQL is an acceptable fallback when the generated CLI wrapper is incomplete.
+
+## Definition of Done
+- [ ] Implementation complete
+- [ ] Tests pass
+- [ ] Review complete
+- [ ] Docs updated
+
+## Evidence Log
+- 2026-03-28: Synced to Linear as `BAR-74` (https://linear.app/bartvandermeeren/issue/BAR-74/t-007-map-planning-scope-to-milestones-and-linear-execution).
+- 2026-03-28: Task created during predictive typing planning pass.

--- a/.project/projects/predictive-typing-quality-trust/tasks/T-008-prepare-beta-readiness-scorecard-and-go-no-go-gates.md
+++ b/.project/projects/predictive-typing-quality-trust/tasks/T-008-prepare-beta-readiness-scorecard-and-go-no-go-gates.md
@@ -1,0 +1,38 @@
+---
+id: T-008
+name: Prepare beta-readiness scorecard and go-no-go gates
+status: ready
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:35:00Z
+linear_issue_id: 78fd5fbb-74f5-4cdd-86fb-d88bc1c5bb4b
+github_issue:
+github_pr:
+depends_on: [T-002, T-003, T-004, T-005, T-006]
+conflicts_with: []
+parallel: false
+priority: medium
+estimate: S
+---
+
+# Task: Prepare beta-readiness scorecard and go-no-go gates
+
+## Description
+Define the final scorecard and thresholds that decide whether predictive typing changes are ready for beta exposure across latency, trust, multilingual behavior, and personalization.
+
+## Acceptance Criteria
+- [ ] The scorecard includes latency, suggestion quality, trust, multilingual, and personalization guardrail metrics.
+- [ ] Beta stop conditions are explicit for trust regressions and multilingual failures.
+- [ ] The scorecard can compare simpler versus richer model stacks without hiding latency cost.
+
+## Technical Notes
+This should prevent shipping a faster but less trusted typing experience and should make architecture trade-offs legible at release time.
+
+## Definition of Done
+- [ ] Implementation complete
+- [ ] Tests pass
+- [ ] Review complete
+- [ ] Docs updated
+
+## Evidence Log
+- 2026-03-28: Synced to Linear as `BAR-75` (https://linear.app/bartvandermeeren/issue/BAR-75/t-008-prepare-beta-readiness-scorecard-and-gono-go-gates).
+- 2026-03-28: Task created during predictive typing planning pass.

--- a/.project/projects/predictive-typing-quality-trust/updates/2026-03-28-initial-planning-and-linear-sync.md
+++ b/.project/projects/predictive-typing-quality-trust/updates/2026-03-28-initial-planning-and-linear-sync.md
@@ -1,0 +1,25 @@
+---
+timestamp: 2026-03-28T11:35:00Z
+status: complete
+task: planning
+stream: multi-stream
+---
+
+# Progress Update
+
+## Completed
+- Created a new Delano planning scope `predictive-typing-quality-trust` parallel to `typing-speed-core`.
+- Wrote the spec, delivery plan, workstreams, task backlog, decision log, and planning update for the new scope.
+- Folded Bart's `Keyboard prediction methodes.md` research note into the Delano artifacts and Linear project/issue copy, especially around hybrid decoder stacks, method-family trade-offs, personalization, privacy, and locale strategy.
+
+## In Progress
+- Local registry, workstream metadata, plan frontmatter, and task frontmatter all include confirmed Linear IDs.
+- Linear project, milestones, labels, and initial issues were created successfully.
+
+## Blockers
+- The shared ChatGPT research page is still unreadable in this run, so source-specific citations remain pending user follow-up.
+- Repository-wide validation still contains a pre-existing absolute-path leakage issue in `typing-speed-core` evidence logs.
+
+## Next Actions
+- Commit the planning branch with the synchronized Delano and Linear artifacts.
+- Keep source-level citations as a follow-up once the original ChatGPT share can be reconstructed if still needed.

--- a/.project/projects/predictive-typing-quality-trust/workstreams/ws-1-benchmark-and-latency-budget.md
+++ b/.project/projects/predictive-typing-quality-trust/workstreams/ws-1-benchmark-and-latency-budget.md
@@ -1,0 +1,30 @@
+---
+name: WS-1 Benchmark and Latency Budget
+owner: product-performance-team
+status: planned
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:27:04Z
+linear_milestone_id: 90330589-1cb2-476e-84e1-2892baa0140e
+linear_label_id: 7b3080d8-8eef-4fb4-8c23-b32877ed1f19
+---
+
+# Workstream: WS-1 Benchmark and Latency Budget
+
+## Objective
+Define the benchmark corpus, latency envelopes, and measurement rules needed to evaluate predictive typing quality without hiding regressions behind average-case metrics.
+
+## Owned Files/Areas
+- Benchmark corpus definitions
+- KPI definitions and test scenarios
+- Latency budget and warm-start acceptance thresholds
+
+## Dependencies
+- Product context and typing-risk assumptions from the spec
+
+## Conflict Risk Zones
+- Shared KPI definitions in the spec and rollout plan
+- Any future benchmark fixtures that also feed implementation tests
+
+## Handoff Criteria
+- Benchmark scenarios cover EN, NL, and mixed-language typing cases
+- Latency and readiness thresholds are explicit and measurable

--- a/.project/projects/predictive-typing-quality-trust/workstreams/ws-2-trust-first-correction-ux.md
+++ b/.project/projects/predictive-typing-quality-trust/workstreams/ws-2-trust-first-correction-ux.md
@@ -1,0 +1,29 @@
+---
+name: WS-2 Trust-first Correction UX
+owner: ime-ux-team
+status: planned
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:27:04Z
+linear_milestone_id: abc7199a-9a91-4125-b49e-ed15f90646c8
+linear_label_id: b9a719a0-b85b-43ec-96b9-a9fce0cba2e6
+---
+
+# Workstream: WS-2 Trust-first Correction UX
+
+## Objective
+Define when predictive typing should help, when autocorrect should stay conservative, and how users recover instantly when the system gets it wrong.
+
+## Owned Files/Areas
+- Autocorrect confidence and suppression rules
+- Undo and backspace recovery behavior
+- Tuning surface and user-facing clarity rules
+
+## Dependencies
+- WS-1 baseline metrics for trust and latency trade-offs
+
+## Conflict Risk Zones
+- Shared settings and copy decisions that may overlap with multilingual or personalization policy
+
+## Handoff Criteria
+- Trust policy is explicit for correct, uncertain, and suppressed cases
+- Recovery flows are clear, reversible, and measurable

--- a/.project/projects/predictive-typing-quality-trust/workstreams/ws-3-multilingual-personalization-strategy.md
+++ b/.project/projects/predictive-typing-quality-trust/workstreams/ws-3-multilingual-personalization-strategy.md
@@ -1,0 +1,30 @@
+---
+name: WS-3 Multilingual Personalization Strategy
+owner: language-modeling-team
+status: planned
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:27:04Z
+linear_milestone_id: 2897763b-449d-45bc-adae-4c292f2fe0c9
+linear_label_id: 78a03d13-7f99-4909-bb36-604b944a4e21
+---
+
+# Workstream: WS-3 Multilingual Personalization Strategy
+
+## Objective
+Define how OwnKey handles EN/NL code-switching and user-specific vocabulary without poisoning predictions or crossing privacy boundaries.
+
+## Owned Files/Areas
+- Mixed-language routing and ranking behavior
+- Personal dictionary partitioning and promotion rules
+- Never-correct and suppression policy inputs
+
+## Dependencies
+- WS-1 corpus coverage for multilingual and name-heavy scenarios
+- WS-2 trust policy for suppression and reversibility
+
+## Conflict Risk Zones
+- Shared dictionary-policy definitions that can affect both autocorrect trust and rollout metrics
+
+## Handoff Criteria
+- Mixed-language decision rules are documented and testable
+- Personalization policy balances speed-to-benefit with noise control

--- a/.project/projects/predictive-typing-quality-trust/workstreams/ws-4-rollout-readiness-and-kpi-governance.md
+++ b/.project/projects/predictive-typing-quality-trust/workstreams/ws-4-rollout-readiness-and-kpi-governance.md
@@ -1,0 +1,29 @@
+---
+name: WS-4 Rollout Readiness and KPI Governance
+owner: delivery-observability-team
+status: planned
+created: 2026-03-28T11:19:17Z
+updated: 2026-03-28T11:27:04Z
+linear_milestone_id: 402d61ef-4959-4668-aaa1-b618dd8cdd1f
+linear_label_id: 52cfea6e-bc1d-48f8-a265-afb0f7520395
+---
+
+# Workstream: WS-4 Rollout Readiness and KPI Governance
+
+## Objective
+Turn the planning package into a sequenced roadmap with measurable release gates, milestone ownership, and tracker synchronization.
+
+## Owned Files/Areas
+- Milestone definitions and issue mapping
+- KPI rollout gates
+- Delano to Linear registry hygiene
+
+## Dependencies
+- WS-1 through WS-3 planning outputs
+
+## Conflict Risk Zones
+- Shared registry and frontmatter mapping fields used by the whole project
+
+## Handoff Criteria
+- Milestones and issues exist in Linear or are explicitly documented as manual follow-up
+- Rollout gates are tied to measurable success criteria

--- a/.project/projects/typing-speed-core/decisions.md
+++ b/.project/projects/typing-speed-core/decisions.md
@@ -7,3 +7,7 @@ Track key project decisions with context and rationale.
 - Keep all typing-speed instrumentation aggregate-only, no raw typed text persisted.
 - Execute typing-speed roadmap sequentially by task ID (T-001 onward) on `feat/speed-prediction-autocorrect`.
 - Require compile + unit-test validation before pushing each task commit.
+
+## 2026-03-28
+
+- Treat explicit autocorrect revert actions as strong negative feedback and seed a per-language protected-spelling list from them before building the broader manual never-correct UI.

--- a/.project/projects/typing-speed-core/plan.md
+++ b/.project/projects/typing-speed-core/plan.md
@@ -3,7 +3,7 @@ name: Typing Speed Core
 status: planned
 lead: ownkey-keyboard-team
 created: 2026-02-25T19:38:38Z
-updated: 2026-02-25T19:38:38Z
+updated: 2026-03-28T17:16:03Z
 linear_project_id:
 ---
 
@@ -58,3 +58,4 @@ linear_project_id:
 12. Improve symbols/numbers flow to reduce mode-switches while preserving prediction continuity.
 13. Optimize keyboard open + first input path to meet <200 ms perceived responsiveness.
 14. Validate KPI trajectory and adjust thresholds before broad rollout.
+15. Remember reverted autocorrect spellings so repeated user-rejected corrections stop auto-committing immediately, then expose that protected-word list with explicit management UI.

--- a/.project/projects/typing-speed-core/tasks/T-007-app-specific-autocorrect-profiles.md
+++ b/.project/projects/typing-speed-core/tasks/T-007-app-specific-autocorrect-profiles.md
@@ -38,4 +38,4 @@ Must include safe fallback when app context is unknown.
 - 2026-03-01: Integrated app-specific profile scaling into `LatinLanguageProvider` high-certainty autocorrect policy snapshot and suggestion cache signatures so auto-commit behavior can differ per app context without stale cache reuse.
 - 2026-03-01: Added new correction preferences and Typing settings controls for enabling app-specific profiles and configuring chat/email aggressiveness percentages.
 - 2026-03-01: Added `AppSpecificAutocorrectProfilePolicyTest` coverage for package mapping, heuristic fallback, safe default, aggressive/conservative threshold scaling, and disabled-policy passthrough.
-- 2026-03-01: Verified with `JAVA_HOME=/home/bartadmin/.local/jdks/temurin-17 ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --tests "dev.patrickgold.florisboard.ime.nlp.latin.*"` (PASS).
+- 2026-03-01: Verified with `JAVA_HOME=$HOME/.local/jdks/temurin-17 ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --tests "dev.patrickgold.florisboard.ime.nlp.latin.*"` (PASS).

--- a/.project/projects/typing-speed-core/tasks/T-009-symbol-number-flow-with-fewer-mode-switches.md
+++ b/.project/projects/typing-speed-core/tasks/T-009-symbol-number-flow-with-fewer-mode-switches.md
@@ -1,9 +1,9 @@
 ---
 id: T-009
 name: Improve symbol/number flow with fewer mode switches
-status: ready
+status: in_progress
 created: 2026-02-25T19:38:38Z
-updated: 2026-02-25T19:38:38Z
+updated: 2026-03-28T13:11:21Z
 linear_issue_id:
 github_issue:
 github_pr:
@@ -34,3 +34,7 @@ May involve layout shortcuts or temporary symbol rows.
 
 ## Evidence Log
 - 2026-02-25: Task created.
+- 2026-03-28: Started the first execution slice by adding a direct `VIEW_NUMERIC_ADVANCED` popup shortcut to the base `?123` key in `charactersMod/default.json`, reducing one mode-switch interaction for common number and symbol bursts.
+- 2026-03-28: Added `CharactersModifierLayoutTest` plus a JSON structural assertion to lock the new shortcut wiring to `VIEW_NUMERIC_ADVANCED`.
+- 2026-03-28: Delano contract validation passed via `bash .claude/scripts/pm/validate.sh`.
+- 2026-03-28: Local Gradle compile/test/build attempts were blocked in the Codex sandbox because Gradle's file-lock listener could not enumerate network interfaces (`java.net.SocketException: Operation not permitted (Socket creation failed)` from `NetworkInterface.getNetworkInterfaces()`), so APK production must continue via a less-restricted shell or CI.

--- a/.project/projects/typing-speed-core/tasks/T-009-symbol-number-flow-with-fewer-mode-switches.md
+++ b/.project/projects/typing-speed-core/tasks/T-009-symbol-number-flow-with-fewer-mode-switches.md
@@ -3,10 +3,10 @@ id: T-009
 name: Improve symbol/number flow with fewer mode switches
 status: in_progress
 created: 2026-02-25T19:38:38Z
-updated: 2026-03-28T13:11:21Z
+updated: 2026-03-28T13:20:31Z
 linear_issue_id:
 github_issue:
-github_pr:
+github_pr: 7
 depends_on: []
 conflicts_with: []
 parallel: true
@@ -37,4 +37,5 @@ May involve layout shortcuts or temporary symbol rows.
 - 2026-03-28: Started the first execution slice by adding a direct `VIEW_NUMERIC_ADVANCED` popup shortcut to the base `?123` key in `charactersMod/default.json`, reducing one mode-switch interaction for common number and symbol bursts.
 - 2026-03-28: Added `CharactersModifierLayoutTest` plus a JSON structural assertion to lock the new shortcut wiring to `VIEW_NUMERIC_ADVANCED`.
 - 2026-03-28: Delano contract validation passed via `bash .claude/scripts/pm/validate.sh`.
-- 2026-03-28: Local Gradle compile/test/build attempts were blocked in the Codex sandbox because Gradle's file-lock listener could not enumerate network interfaces (`java.net.SocketException: Operation not permitted (Socket creation failed)` from `NetworkInterface.getNetworkInterfaces()`), so APK production must continue via a less-restricted shell or CI.
+- 2026-03-28: Local Gradle compile/test/build attempts were blocked in the Codex sandbox because Gradle's file-lock listener could not enumerate network interfaces (`java.net.SocketException: Operation not permitted (Socket creation failed)` from `NetworkInterface.getNetworkInterfaces()`), so APK production continued via CI.
+- 2026-03-28: Opened GitHub PR #7 and verified Android CI run `23686005603` succeeded with phone artifact `ownkey-phone-debug-v0.6.0-alpha02-1d8be84.apk`.

--- a/.project/projects/typing-speed-core/tasks/T-012-smart-backspace-for-corrected-words.md
+++ b/.project/projects/typing-speed-core/tasks/T-012-smart-backspace-for-corrected-words.md
@@ -1,12 +1,12 @@
 ---
 id: T-012
 name: Add smart backspace recovery for corrected words
-status: ready
+status: review
 created: 2026-02-25T19:38:38Z
-updated: 2026-02-25T19:38:38Z
+updated: 2026-03-28T17:40:00Z
 linear_issue_id:
 github_issue:
-github_pr:
+github_pr: 7
 depends_on: [T-004]
 conflicts_with: []
 parallel: true
@@ -20,17 +20,23 @@ estimate: M
 Make backspace context-aware so recently autocorrected words can be restored quickly.
 
 ## Acceptance Criteria
-- [ ] Backspace restores corrected token form in expected contexts.
-- [ ] Standard backspace behavior remains unchanged elsewhere.
+- [x] Backspace restores corrected token form in expected contexts.
+- [x] Standard backspace behavior remains unchanged elsewhere.
 
 ## Technical Notes
-Share correction history model with one-tap undo behavior.
+Share correction history model with one-tap undo behavior, but keep the backspace path narrower than the explicit undo action: only restore the latest autocorrect when the cursor is still at the end of that corrected word or directly after its trailing separator.
 
 ## Definition of Done
-- [ ] Implementation complete
-- [ ] Tests pass
+- [x] Implementation complete
+- [x] Tests pass
 - [ ] Review complete
-- [ ] Docs updated
+- [x] Docs updated
 
 ## Evidence Log
 - 2026-02-25: Task created.
+- 2026-03-28: Chose T-012 as the next execution slice after T-014 because Delano already had the trust-policy and one-tap undo groundwork in place, and smart backspace is the next user-meaningful recovery behavior in WS-2.
+- 2026-03-28: Reused `AutocorrectUndoTracker` state for backspace recovery instead of adding a second history model, keeping the behavior aligned with T-004 while avoiding a broader editor rewrite.
+- 2026-03-28: Updated `KeyboardManager.handleBackwardDelete()` to restore the latest tracked autocorrect on normal character backspace before falling through to standard deletion.
+- 2026-03-28: Narrowed the restore window so backspace recovery only fires when the cursor is still at the end of the corrected current word or directly after that token with a trailing separator, leaving mid-word edits and active selections on normal delete behavior.
+- 2026-03-28: Added `AutocorrectUndoTrackerTest` coverage for trailing-space restore, current-word-end restore, mid-word no-restore, and active-selection no-restore.
+- 2026-03-28: Verified with `JAVA_HOME=$HOME/.local/jdks/temurin-17 ./gradlew --no-daemon --no-watch-fs :app:testDebugUnitTest` (PASS) and `bash .claude/scripts/pm/validate.sh` (PASS).

--- a/.project/projects/typing-speed-core/tasks/T-014-mainstream-spacing-for-accepted-corrections.md
+++ b/.project/projects/typing-speed-core/tasks/T-014-mainstream-spacing-for-accepted-corrections.md
@@ -1,0 +1,42 @@
+---
+id: T-014
+name: Make accepted corrections reuse existing spacing like mainstream keyboards
+status: review
+created: 2026-03-28T16:45:00Z
+updated: 2026-03-28T17:05:00Z
+linear_issue_id:
+github_issue:
+github_pr: 7
+depends_on: [T-003, T-004]
+conflicts_with: []
+parallel: true
+priority: medium
+estimate: S
+---
+
+# Task: Make accepted corrections reuse existing spacing like mainstream keyboards
+
+## Description
+Prevent correction/suggestion acceptance from leaving the cursor in front of an already-existing space while still preserving punctuation-friendly phantom spacing when no literal separator exists yet.
+
+## Acceptance Criteria
+- [x] Accepting a suggestion at the live cursor keeps pending separator behavior for punctuation-friendly continuation.
+- [x] Accepting a correction before an existing trailing space reuses that literal space instead of arming a second separator path.
+- [x] Focused tests cover accepted-suggestion spacing decisions and the affected layout regression test path remains green.
+
+## Technical Notes
+Keep candidate-revert tracking alive even when phantom spacing is intentionally disabled for an accepted correction that already has a literal separator.
+
+## Definition of Done
+- [x] Implementation complete
+- [x] Tests pass
+- [ ] Review complete
+- [x] Docs updated
+
+## Evidence Log
+- 2026-03-28: Task created and completed on PR #7.
+- 2026-03-28: Root cause confirmed in `EditorInstance.commitCompletion()`: accepted suggestions always armed phantom spacing, even when correcting a word that already had a literal trailing space, leaving the cursor before that space and making the next separator tap create doubles.
+- 2026-03-28: Added `AcceptedSuggestionSpacingPolicy` and wired `commitCompletion()` + `finalizeComposingText()` to reuse an immediate trailing literal space by advancing the cursor past it while disabling phantom separator insertion for that case.
+- 2026-03-28: Preserved backspace-revert tracking by letting `PhantomSpaceState` retain the accepted candidate even when separator insertion is disabled.
+- 2026-03-28: Added `AcceptedSuggestionSpacingPolicyTest` coverage for live-cursor acceptance, trailing-space reuse, and punctuation-following acceptance.
+- 2026-03-28: Verified with `JAVA_HOME=$HOME/.local/jdks/temurin-17 ./gradlew --no-daemon --no-watch-fs :app:testDebugUnitTest` (PASS).

--- a/.project/projects/typing-speed-core/tasks/T-015-remember-reverted-autocorrect-spellings.md
+++ b/.project/projects/typing-speed-core/tasks/T-015-remember-reverted-autocorrect-spellings.md
@@ -1,0 +1,40 @@
+---
+id: T-015
+name: Remember reverted autocorrect spellings
+status: review
+created: 2026-03-28T17:16:03Z
+updated: 2026-03-28T17:16:03Z
+linear_issue_id:
+github_issue:
+github_pr:
+depends_on: [T-004, T-012]
+conflicts_with: []
+parallel: true
+priority: high
+estimate: S
+---
+
+# Task: Remember reverted autocorrect spellings
+
+## Description
+When the user explicitly reverts an autocorrect, remember the original spelling per language and suppress future auto-commit for that spelling.
+
+## Acceptance Criteria
+- [x] Reverted autocorrect spellings are remembered per language.
+- [x] Protected spellings still appear in suggestions when relevant, but they no longer auto-commit.
+
+## Technical Notes
+This is a trust-first bridge toward the broader never-correct list. Treat explicit user revert actions as strong negative feedback for future autocorrect, without adding broad new settings UI in the same slice.
+
+## Definition of Done
+- [x] Implementation complete
+- [x] Tests pass
+- [ ] Review complete
+- [x] Docs updated
+
+## Evidence Log
+- 2026-03-28: Task created after reviewing the current predictive-typing branch state and Delano backlog.
+- 2026-03-28: Added persistent `NeverCorrectWords` storage in preferences and wired `LatinLanguageProvider` to suppress auto-commit when the current normalized input is protected for the active language.
+- 2026-03-28: Extended autocorrect revert notifications to include the restored original token so explicit undo/backspace recovery can seed the protection list immediately.
+- 2026-03-28: Added focused tests for protected-word storage/scoping, policy-level suppression, and undo-tracker original-token lookup.
+- 2026-03-28: Verified with `JAVA_HOME=$HOME/.local/jdks/temurin-17 ./gradlew --no-daemon --no-watch-fs :app:testDebugUnitTest` and `bash .claude/scripts/pm/validate.sh` (PASS).

--- a/.project/projects/typing-speed-core/tasks/T-016-refresh-next-word-suggestions-after-accepted-suggestions.md
+++ b/.project/projects/typing-speed-core/tasks/T-016-refresh-next-word-suggestions-after-accepted-suggestions.md
@@ -1,0 +1,40 @@
+---
+id: T-016
+name: Refresh next-word suggestions immediately after accepted suggestions
+status: review
+created: 2026-03-28T18:35:00Z
+updated: 2026-03-28T18:35:00Z
+linear_issue_id:
+github_issue:
+github_pr: 7
+depends_on: [T-014]
+conflicts_with: []
+parallel: true
+priority: high
+estimate: S
+---
+
+# Task: Refresh next-word suggestions immediately after accepted suggestions
+
+## Description
+When a user taps a suggestion and OwnKey keeps a pending phantom separator instead of inserting a hard space, refresh the suggestion row immediately with follow-up next-word suggestions instead of waiting for the next literal keypress.
+
+## Acceptance Criteria
+- [x] After accepting a suggestion that leaves a pending separator, the next suggestion refresh treats that state like a next-word boundary immediately.
+- [x] The fix is scoped to pending-separator refresh context and does not globally force extra refreshes for unrelated suggestion modes.
+- [x] Focused tests cover the synthesized follow-up suggestion context.
+
+## Technical Notes
+Use the pending separator as the contract source of truth. The NLP layer should receive a virtual boundary context, not a generic forced refresh, so recent spacing, punctuation, undo/backspace recovery, and reverted-autocorrect suppression behavior stay intact.
+
+## Definition of Done
+- [x] Implementation complete
+- [x] Tests pass
+- [ ] Review complete
+- [x] Docs updated
+
+## Evidence Log
+- 2026-03-28: Root cause confirmed in `KeyboardManager.resetSuggestions()`: after accepted suggestions, the refresh path passed the literal editor snapshot to `nlpManager.suggest()`, so the NLP layer still saw the cursor attached to the committed word whenever phantom spacing was pending.
+- 2026-03-28: Because next-word prediction in `LatinLanguageProvider` only activates on an actual boundary, suggestion acceptance could leave the row empty until the user typed a space or another letter.
+- 2026-03-28: Added `PendingSeparatorSuggestionContent` so refreshes synthesize a virtual boundary only while `editorInstance.phantomSpace.isActive`, then wired `KeyboardManager.resetSuggestions()` to use that derived context.
+- 2026-03-28: Added focused unit tests for pending-separator refresh behavior and re-ran full local unit + Delano validation successfully.

--- a/.project/projects/typing-speed-core/updates/2026-03-01-t007-app-specific-autocorrect-profiles.md
+++ b/.project/projects/typing-speed-core/updates/2026-03-01-t007-app-specific-autocorrect-profiles.md
@@ -16,7 +16,7 @@ stream: ws-4-context-policy-and-metrics
 - Added unit tests in `AppSpecificAutocorrectProfilePolicyTest` for package mapping, heuristic fallback, safe default behavior, and aggressiveness scaling.
 
 ## Verification
-- `JAVA_HOME=/home/bartadmin/.local/jdks/temurin-17 ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --tests "dev.patrickgold.florisboard.ime.nlp.latin.*"` (pass)
+- `JAVA_HOME=$HOME/.local/jdks/temurin-17 ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest --tests "dev.patrickgold.florisboard.ime.nlp.latin.*"` (pass)
 
 ## Privacy Notes
 - App-context handling is based on editor metadata (`packageName`, input variation, IME action) already provided by the Android IME framework.

--- a/.project/projects/typing-speed-core/updates/2026-03-28-t009-symbol-number-shortcut.md
+++ b/.project/projects/typing-speed-core/updates/2026-03-28-t009-symbol-number-shortcut.md
@@ -1,0 +1,32 @@
+---
+title: T-009 first execution slice - direct numeric-advanced shortcut
+created: 2026-03-28T13:11:21Z
+updated: 2026-03-28T13:11:21Z
+task_id: T-009
+---
+
+# Update Summary
+Implemented the first dependency-safe execution slice for T-009 by extending the shared `?123` key on the base characters modifier row with a direct popup shortcut to `VIEW_NUMERIC_ADVANCED`.
+
+## Why this slice first
+- `./.agents/scripts/pm/next.sh --all` identified T-009 as the next dependency-safe implementation task.
+- This change stays inside the existing layout system rather than introducing new keyboard-mode state.
+- It removes one interaction for common number and symbol bursts while preserving current prediction and correction behavior.
+- It is safe to ship independently even if later T-009 follow-up work adds more ambitious momentary-symbol or auto-return behavior.
+
+## Files Changed
+- `app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/charactersMod/default.json`
+- `app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/CharactersModifierLayoutTest.kt`
+- `.project/projects/typing-speed-core/tasks/T-009-symbol-number-flow-with-fewer-mode-switches.md`
+
+## Validation
+- `bash .claude/scripts/pm/validate.sh` — PASS
+- `python3` JSON structural assertion against `charactersMod/default.json` — PASS
+- Gradle compile/test/build attempt with local Temurin 17 — BLOCKED by sandbox runtime
+  - Observed failure: `java.net.SocketException: Operation not permitted (Socket creation failed)`
+  - Failing call path: Gradle file-lock listener startup -> `NetworkInterface.getNetworkInterfaces()`
+  - Interpretation: environment blocker, not a code-level compile failure discovered in this pass
+
+## Follow-up
+- Run the Gradle validation and APK build in CI or a shell without the sandbox network-interface restriction.
+- If user testing still shows too much layer friction after this shortcut, continue T-009 with a second slice focused on momentary symbol/number return behavior.

--- a/.project/projects/typing-speed-core/updates/2026-03-28-t009-symbol-number-shortcut.md
+++ b/.project/projects/typing-speed-core/updates/2026-03-28-t009-symbol-number-shortcut.md
@@ -1,7 +1,7 @@
 ---
 title: T-009 first execution slice - direct numeric-advanced shortcut
 created: 2026-03-28T13:11:21Z
-updated: 2026-03-28T13:11:21Z
+updated: 2026-03-28T13:20:31Z
 task_id: T-009
 ---
 
@@ -27,6 +27,12 @@ Implemented the first dependency-safe execution slice for T-009 by extending the
   - Failing call path: Gradle file-lock listener startup -> `NetworkInterface.getNetworkInterfaces()`
   - Interpretation: environment blocker, not a code-level compile failure discovered in this pass
 
+## CI Outcome
+- GitHub PR: `https://github.com/MajesteitBart/ownkey-keyboard/pull/7`
+- Successful Android CI run: `https://github.com/MajesteitBart/ownkey-keyboard/actions/runs/23686005603`
+- Phone artifact: `https://github.com/MajesteitBart/ownkey-keyboard/actions/runs/23686005603/artifacts/6158810158`
+  - Contains `ownkey-phone-debug-v0.6.0-alpha02-1d8be84.apk`
+
 ## Follow-up
-- Run the Gradle validation and APK build in CI or a shell without the sandbox network-interface restriction.
+- If a local developer shell without the sandbox restriction is available, re-run the focused Gradle validation there so the local execution path matches CI.
 - If user testing still shows too much layer friction after this shortcut, continue T-009 with a second slice focused on momentary symbol/number return behavior.

--- a/.project/projects/typing-speed-core/updates/2026-03-28-t012-smart-backspace-recovery.md
+++ b/.project/projects/typing-speed-core/updates/2026-03-28-t012-smart-backspace-recovery.md
@@ -1,0 +1,43 @@
+---
+title: T-012 smart backspace recovery for corrected words
+timestamp: 2026-03-28T17:40:00Z
+status: review
+task: T-012
+stream: ws-2-autocorrect-control-and-recovery-ux
+---
+
+# Progress Update
+
+## Why this slice was next
+- The predictive-typing planning project still has planning/admin work open, but the highest-value dependency-safe user behavior in the implementation stream was `typing-speed-core` T-012.
+- T-004 already shipped the shared autocorrect history model and explicit undo path, so smart backspace could now be added without inventing new persistence or broad editor state.
+- This directly improves trust in real typing by making the most common "keyboard changed my word" recovery gesture behave like mainstream mobile keyboards.
+
+## Completed
+- Reused `AutocorrectUndoTracker` for a new backspace-specific lookup path instead of introducing a second recovery history.
+- Added a narrower restore contract for backspace than for explicit undo:
+  - restore when the cursor is still at the end of the corrected current word
+  - restore when the cursor is directly after that corrected token with a trailing separator
+  - do not restore for active selections or when the cursor has moved into the middle of the word
+- Updated `KeyboardManager.handleBackwardDelete()` to restore the tracked autocorrect before normal deletion when the backspace context matches.
+- Refactored the actual replacement/metrics/provider-notification flow into a shared helper so backspace restore and one-tap undo stay behaviorally aligned.
+
+## Behavioral Contract After This Change
+- First backspace after a recent autocorrect can restore the original typed token instead of deleting a character from the corrected output.
+- Once the cursor context no longer matches that immediate recovery window, backspace falls through to normal delete behavior.
+- Manual selections and mid-word cursor edits keep standard deletion semantics.
+
+## Verification
+- `JAVA_HOME=$HOME/.local/jdks/temurin-17 ./gradlew --no-daemon --no-watch-fs :app:testDebugUnitTest --tests dev.patrickgold.florisboard.ime.keyboard.AutocorrectUndoTrackerTest` (pass)
+- `JAVA_HOME=$HOME/.local/jdks/temurin-17 ./gradlew --no-daemon --no-watch-fs :app:testDebugUnitTest` (pass)
+- `bash .claude/scripts/pm/validate.sh` (pass)
+
+## Files Changed
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTracker.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt`
+- `app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTrackerTest.kt`
+- `.project/projects/typing-speed-core/tasks/T-012-smart-backspace-for-corrected-words.md`
+
+## Next Actions
+- Push the branch head so PR #7 picks up the backspace recovery slice.
+- Use device QA or CI artifact testing to confirm the restored-token cursor position feels right in real text fields, especially after trailing spaces and quick follow-up backspaces.

--- a/.project/projects/typing-speed-core/updates/2026-03-28-t014-accepted-suggestion-spacing.md
+++ b/.project/projects/typing-speed-core/updates/2026-03-28-t014-accepted-suggestion-spacing.md
@@ -1,0 +1,38 @@
+---
+title: T-014 accepted suggestion spacing contract
+timestamp: 2026-03-28T17:05:00Z
+status: review
+task: T-014
+stream: ws-2-autocorrect-control-and-recovery-ux
+---
+
+# Progress Update
+
+## Completed
+- Diagnosed the real double-space path around accepted corrections instead of reverting the earlier punctuation-friendly phantom-space change.
+- Added `AcceptedSuggestionSpacingPolicy` to distinguish between two contracts:
+  - live acceptance at the cursor with no literal separator yet -> keep phantom spacing active
+  - correction acceptance with an immediate trailing literal space -> reuse that separator and advance the cursor past it
+- Extended `AbstractEditorInstance.finalizeComposingText()` with an optional cursor-advance parameter so correction acceptance can preserve existing separator position in the same commit flow.
+- Updated `EditorInstance.commitCompletion()` to apply the new spacing decision and to keep revert metadata while disabling separator insertion for reuse cases.
+- Made `CharactersModifierLayoutTest` path-robust so the full local unit-test target can run cleanly from the Gradle module working directory.
+
+## Behavioral Contract After This Change
+- Tapping or auto-accepting a suggestion at the active cursor still supports punctuation-friendly follow-up without an inserted hard space.
+- Accepting a correction for a word that already has a literal trailing space now reuses that space instead of leaving the cursor before it.
+- The fix is scoped to accepted-suggestion completion flow. It does not globally normalize whitespace or rewrite unrelated spacing rules.
+
+## Verification
+- `JAVA_HOME=$HOME/.local/jdks/temurin-17 ./gradlew --no-daemon --no-watch-fs :app:testDebugUnitTest` (pass)
+
+## Files Changed
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AcceptedSuggestionSpacingPolicy.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt`
+- `app/src/test/kotlin/dev/patrickgold/florisboard/ime/editor/AcceptedSuggestionSpacingPolicyTest.kt`
+- `app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/CharactersModifierLayoutTest.kt`
+- `.project/projects/typing-speed-core/tasks/T-014-mainstream-spacing-for-accepted-corrections.md`
+
+## Next Actions
+- Push the branch head so PR #7 picks up the spacing fix.
+- If device QA still finds awkward mid-sentence correction cases around punctuation or multi-space text, capture those as a follow-up rather than broadening this contract silently.

--- a/.project/projects/typing-speed-core/updates/2026-03-28-t015-reverted-autocorrect-suppression.md
+++ b/.project/projects/typing-speed-core/updates/2026-03-28-t015-reverted-autocorrect-suppression.md
@@ -1,0 +1,53 @@
+---
+title: T-015 remember reverted autocorrect spellings
+timestamp: 2026-03-28T17:16:03Z
+status: review
+task: T-015
+stream: ws-2-autocorrect-control-and-recovery-ux
+---
+
+# Progress Update
+
+## Why this slice was next
+- The existing `typing-speed-core` backlog already had a later full `never-correct list` task, but the repo state showed a smaller and more immediate trust gap: OwnKey already tracked autocorrect undo/backspace restores, yet that explicit user feedback did not change future auto-commit behavior.
+- This slice is dependency-safe because T-004 and T-012 already capture the exact original token and recovery event needed to act on a revert without new editor architecture.
+- It materially improves trust in real typing by stopping the keyboard from repeating the same false autocorrect right after the user just corrected it.
+
+## Completed
+- Added persistent `NeverCorrectWords` storage under preferences with per-language scoping, deduping, and targeted removal support for later UI work.
+- Extended `SuggestionProvider.notifySuggestionReverted()` so undo/backspace recovery can pass the restored original token to language providers.
+- Updated `KeyboardManager` and `AutocorrectUndoTracker` so revert notifications carry the original typed word whenever the reverted candidate matches the tracked autocorrect.
+- Wired `LatinLanguageProvider` to:
+  - add reverted autocorrect spellings to the protected-word store
+  - clear suggestion cache after a new protection entry is learned
+  - suppress future auto-commit for protected inputs while still allowing the suggestion row to surface candidates normally
+- Added focused tests for the new protected-word store, the policy-level auto-commit block, and original-token lookup from tracked autocorrect state.
+
+## Behavioral Contract After This Change
+- If OwnKey autocorrects a word and the user explicitly restores the original spelling via undo or smart backspace, that original spelling becomes protected for the active language.
+- The next time the user types that same protected spelling, OwnKey can still suggest alternatives, but it will not auto-commit over the user’s chosen spelling.
+- Protection is scoped by language so a reverted spelling in one language does not automatically suppress another language’s behavior.
+
+## Verification
+- `JAVA_HOME=$HOME/.local/jdks/temurin-17 ./gradlew --no-daemon --no-watch-fs :app:testDebugUnitTest` (pass)
+- `bash .claude/scripts/pm/validate.sh` (pass)
+
+## Files Changed
+- `app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTracker.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpManager.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpProviders.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/han/HanShapeBasedLanguageProvider.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/HighCertaintyAutocorrectPolicy.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/NeverCorrectWords.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt`
+- `app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTrackerTest.kt`
+- `app/src/test/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/HighCertaintyAutocorrectPolicyTest.kt`
+- `app/src/test/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/NeverCorrectWordsTest.kt`
+- `.project/projects/typing-speed-core/tasks/T-015-remember-reverted-autocorrect-spellings.md`
+
+## Next Actions
+- Push the branch head so PR #7 and CI pick up the new trust behavior.
+- In a later UX slice, expose the protected-word list through a user-manageable screen so entries can be reviewed, added manually, or removed without waiting for another revert event.

--- a/.project/projects/typing-speed-core/updates/2026-03-28-t016-post-accept-suggestion-refresh.md
+++ b/.project/projects/typing-speed-core/updates/2026-03-28-t016-post-accept-suggestion-refresh.md
@@ -1,0 +1,36 @@
+---
+title: T-016 immediate follow-up suggestions after accepted suggestions
+timestamp: 2026-03-28T18:35:00Z
+status: review
+task: T-016
+stream: ws-2-autocorrect-control-and-recovery-ux
+---
+
+# Progress Update
+
+## Completed
+- Diagnosed the post-accept suggestion gap without broadening the earlier spacing/recovery fixes.
+- Confirmed the real contract break: accepted suggestions often leave `phantomSpace` active, but `KeyboardManager.resetSuggestions()` was still refreshing from the literal editor snapshot, which has no real boundary yet.
+- Added `PendingSeparatorSuggestionContent` to synthesize a virtual boundary only for suggestion refresh when a pending separator exists.
+- Updated `KeyboardManager.resetSuggestions()` to send the derived context to `nlpManager.suggest()` instead of forcing a generic extra refresh.
+- Added focused unit coverage for pending-separator refresh behavior and re-ran full local validation.
+
+## Behavioral Contract After This Change
+- After tapping a suggestion that leaves a pending separator, OwnKey now refreshes the row as if the accepted word is already followed by a boundary, so next-word suggestions can appear immediately.
+- The change is scoped to the pending-separator state. Literal editor content remains unchanged, and unrelated suggestion modes still refresh from the real editor snapshot.
+- Existing trust work remains intact because this slice only changes the suggestion-refresh context, not spacing insertion, undo/backspace recovery, or reverted-autocorrect suppression rules.
+
+## Verification
+- `JAVA_HOME=$HOME/.local/jdks/temurin-17 ./gradlew --no-daemon --no-watch-fs :app:testDebugUnitTest --tests dev.patrickgold.florisboard.ime.editor.PendingSeparatorSuggestionContentTest` (pass)
+- `JAVA_HOME=$HOME/.local/jdks/temurin-17 ./gradlew --no-daemon --no-watch-fs :app:testDebugUnitTest` (pass)
+- `bash .claude/scripts/pm/validate.sh` (pass)
+
+## Files Changed
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/PendingSeparatorSuggestionContent.kt`
+- `app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt`
+- `app/src/test/kotlin/dev/patrickgold/florisboard/ime/editor/PendingSeparatorSuggestionContentTest.kt`
+- `.project/projects/typing-speed-core/tasks/T-016-refresh-next-word-suggestions-after-accepted-suggestions.md`
+
+## Next Actions
+- Push the branch head so PR #7 and CI pick up the post-accept refresh fix.
+- Device QA should confirm the row now repopulates immediately after tapped suggestions in common chat/text fields, especially around punctuation continuation after the pending separator state.

--- a/.project/registry/linear-map.json
+++ b/.project/registry/linear-map.json
@@ -1,11 +1,103 @@
 {
   "version": 1,
-  "updated": "2026-02-25T19:38:38Z",
+  "updated": "2026-03-28T11:27:04Z",
   "projects": {
     "typing-speed-core": {
       "linear_project_id": null,
       "status": "planned"
+    },
+    "predictive-typing-quality-trust": {
+      "linear_project_id": "8e478486-d8e6-44e4-bac7-5a55c6bbdba8",
+      "linear_project_url": "https://linear.app/bartvandermeeren/project/predictive-typing-quality-and-trust-774d3d5b8a58",
+      "team_id": "158cbf11-fbe2-45e3-abb0-e195acbec1be",
+      "team_key": "BAR",
+      "status": "planned",
+      "milestones": {
+        "M1 Benchmark Baseline": "90330589-1cb2-476e-84e1-2892baa0140e",
+        "M2 Trust Policy Definition": "abc7199a-9a91-4125-b49e-ed15f90646c8",
+        "M3 Multilingual Personalization Plan": "2897763b-449d-45bc-adae-4c292f2fe0c9",
+        "M4 Delivery Readiness": "402d61ef-4959-4668-aaa1-b618dd8cdd1f"
+      },
+      "workstream_labels": {
+        "WS-1 Benchmark & Latency": "7b3080d8-8eef-4fb4-8c23-b32877ed1f19",
+        "WS-2 Trust-first UX": "b9a719a0-b85b-43ec-96b9-a9fce0cba2e6",
+        "WS-3 Multilingual Personalization": "78a03d13-7f99-4909-bb36-604b944a4e21",
+        "WS-4 Rollout & KPI Governance": "52cfea6e-bc1d-48f8-a265-afb0f7520395"
+      }
     }
   },
-  "tasks": {}
+  "tasks": {
+    "predictive-typing-quality-trust/T-001": {
+      "linear_issue_id": "e6a72d3d-5fa4-43d6-8f02-e92b70d93efe",
+      "linear_issue_identifier": "BAR-68",
+      "linear_issue_url": "https://linear.app/bartvandermeeren/issue/BAR-68/t-001-define-benchmark-corpus-and-measurement-protocol",
+      "linear_project_id": "8e478486-d8e6-44e4-bac7-5a55c6bbdba8",
+      "linear_project_milestone_id": "90330589-1cb2-476e-84e1-2892baa0140e",
+      "linear_label_id": "7b3080d8-8eef-4fb4-8c23-b32877ed1f19",
+      "status": "Todo"
+    },
+    "predictive-typing-quality-trust/T-002": {
+      "linear_issue_id": "7153d4f5-e877-4d45-8b22-78421c1381b4",
+      "linear_issue_identifier": "BAR-69",
+      "linear_issue_url": "https://linear.app/bartvandermeeren/issue/BAR-69/t-002-set-latency-budget-and-warm-start-acceptance-bar",
+      "linear_project_id": "8e478486-d8e6-44e4-bac7-5a55c6bbdba8",
+      "linear_project_milestone_id": "90330589-1cb2-476e-84e1-2892baa0140e",
+      "linear_label_id": "7b3080d8-8eef-4fb4-8c23-b32877ed1f19",
+      "status": "Todo"
+    },
+    "predictive-typing-quality-trust/T-003": {
+      "linear_issue_id": "fbc0bfe5-f4e7-486b-9db6-46bfeb3f1372",
+      "linear_issue_identifier": "BAR-70",
+      "linear_issue_url": "https://linear.app/bartvandermeeren/issue/BAR-70/t-003-specify-trust-first-autocorrect-policy-and-recovery-flows",
+      "linear_project_id": "8e478486-d8e6-44e4-bac7-5a55c6bbdba8",
+      "linear_project_milestone_id": "abc7199a-9a91-4125-b49e-ed15f90646c8",
+      "linear_label_id": "b9a719a0-b85b-43ec-96b9-a9fce0cba2e6",
+      "status": "Todo"
+    },
+    "predictive-typing-quality-trust/T-004": {
+      "linear_issue_id": "5768e53f-4136-4e2f-9c50-a1b77db63c1e",
+      "linear_issue_identifier": "BAR-71",
+      "linear_issue_url": "https://linear.app/bartvandermeeren/issue/BAR-71/t-004-define-multilingual-routing-and-code-switching-rules",
+      "linear_project_id": "8e478486-d8e6-44e4-bac7-5a55c6bbdba8",
+      "linear_project_milestone_id": "2897763b-449d-45bc-adae-4c292f2fe0c9",
+      "linear_label_id": "78a03d13-7f99-4909-bb36-604b944a4e21",
+      "status": "Todo"
+    },
+    "predictive-typing-quality-trust/T-005": {
+      "linear_issue_id": "a2397a74-b122-46cc-bb62-a33a11676f4d",
+      "linear_issue_identifier": "BAR-72",
+      "linear_issue_url": "https://linear.app/bartvandermeeren/issue/BAR-72/t-005-define-personalization-learning-policy-and-privacy-guardrails",
+      "linear_project_id": "8e478486-d8e6-44e4-bac7-5a55c6bbdba8",
+      "linear_project_milestone_id": "2897763b-449d-45bc-adae-4c292f2fe0c9",
+      "linear_label_id": "78a03d13-7f99-4909-bb36-604b944a4e21",
+      "status": "Todo"
+    },
+    "predictive-typing-quality-trust/T-006": {
+      "linear_issue_id": "0268e1e8-49ef-44b7-87d1-c478a53826eb",
+      "linear_issue_identifier": "BAR-73",
+      "linear_issue_url": "https://linear.app/bartvandermeeren/issue/BAR-73/t-006-define-tuning-surface-and-user-facing-explainability",
+      "linear_project_id": "8e478486-d8e6-44e4-bac7-5a55c6bbdba8",
+      "linear_project_milestone_id": "abc7199a-9a91-4125-b49e-ed15f90646c8",
+      "linear_label_id": "b9a719a0-b85b-43ec-96b9-a9fce0cba2e6",
+      "status": "Todo"
+    },
+    "predictive-typing-quality-trust/T-007": {
+      "linear_issue_id": "2ecd539a-bffb-426a-8a83-72296f2df395",
+      "linear_issue_identifier": "BAR-74",
+      "linear_issue_url": "https://linear.app/bartvandermeeren/issue/BAR-74/t-007-map-planning-scope-to-milestones-and-linear-execution",
+      "linear_project_id": "8e478486-d8e6-44e4-bac7-5a55c6bbdba8",
+      "linear_project_milestone_id": "402d61ef-4959-4668-aaa1-b618dd8cdd1f",
+      "linear_label_id": "52cfea6e-bc1d-48f8-a265-afb0f7520395",
+      "status": "Todo"
+    },
+    "predictive-typing-quality-trust/T-008": {
+      "linear_issue_id": "78fd5fbb-74f5-4cdd-86fb-d88bc1c5bb4b",
+      "linear_issue_identifier": "BAR-75",
+      "linear_issue_url": "https://linear.app/bartvandermeeren/issue/BAR-75/t-008-prepare-beta-readiness-scorecard-and-gono-go-gates",
+      "linear_project_id": "8e478486-d8e6-44e4-bac7-5a55c6bbdba8",
+      "linear_project_milestone_id": "402d61ef-4959-4668-aaa1-b618dd8cdd1f",
+      "linear_label_id": "52cfea6e-bc1d-48f8-a265-afb0f7520395",
+      "status": "Todo"
+    }
+  }
 }

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/charactersMod/default.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/charactersMod/default.json
@@ -5,7 +5,9 @@
     { "code":   -7, "label": "delete", "type": "enter_editing" }
   ],
   [
-    { "code": -202, "label": "view_symbols", "type": "system_gui" },
+    { "code": -202, "label": "view_symbols", "type": "system_gui", "popup": {
+      "main": { "code": -205, "label": "view_numeric_advanced", "type": "system_gui" }
+    } },
     { "$": "variation_selector",
       "default":  { "code":   44, "label": ",", "groupId": 1 },
       "email":    { "code":   64, "label": "@", "groupId": 1 },

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/app/AppPrefs.kt
@@ -38,6 +38,7 @@ import dev.patrickgold.florisboard.ime.media.emoji.EmojiHistory
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiSkinTone
 import dev.patrickgold.florisboard.ime.media.emoji.EmojiSuggestionType
 import dev.patrickgold.florisboard.ime.nlp.SpellingLanguageMode
+import dev.patrickgold.florisboard.ime.nlp.latin.NeverCorrectWords
 import dev.patrickgold.florisboard.ime.smartbar.CandidatesDisplayMode
 import dev.patrickgold.florisboard.ime.smartbar.ExtendedActionsPlacement
 import dev.patrickgold.florisboard.ime.smartbar.IncognitoDisplayMode
@@ -250,6 +251,11 @@ abstract class FlorisPreferenceModel : PreferenceModel() {
         val enableFlorisUserDictionary = boolean(
             key = "suggestion__enable_floris_user_dictionary",
             default = true,
+        )
+        val neverCorrectWordsData = custom(
+            key = "dictionary__never_correct_words_data",
+            default = NeverCorrectWords.Empty,
+            serializer = NeverCorrectWords.Serializer,
         )
     }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AbstractEditorInstance.kt
@@ -412,7 +412,7 @@ abstract class AbstractEditorInstance(context: Context) {
         return true
     }
 
-    open fun finalizeComposingText(text: String): Boolean {
+    open fun finalizeComposingText(text: String, cursorAdvanceAfterText: Int = 0): Boolean {
         val ic = currentInputConnection() ?: return false
         val content = activeContent
         val composing = content.composing
@@ -420,18 +420,26 @@ abstract class AbstractEditorInstance(context: Context) {
         if (activeInfo.isRawInputEditor || composing.isNotValid) {
             return false
         } else runBlocking {
-            val newSelection = EditorRange.cursor(composing.end + (text.length - content.composingText.length))
+            val safeCursorAdvance = cursorAdvanceAfterText.coerceIn(0, content.textAfterSelection.length)
+            val newSelection = EditorRange.cursor(
+                composing.end + (text.length - content.composingText.length) + safeCursorAdvance
+            )
             val newContent = content.generateCopy(
                 selection = newSelection,
                 textBeforeSelection = buildString {
                     append(content.textBeforeSelection.removeSuffix(content.composingText))
                     append(text)
+                    append(content.textAfterSelection.take(safeCursorAdvance))
                 },
+                textAfterSelection = content.textAfterSelection.drop(safeCursorAdvance),
                 selectedText = "",
             )
             expectedContentQueue.push(newContent)
             ic.setComposingText(text, 1)
             ic.finishComposingText()
+            if (safeCursorAdvance > 0) {
+                ic.setSelection(newSelection.start, newSelection.end)
+            }
             _lastCommitPosition.handleCommit(newContent.selection)
         }
         ic.endBatchEdit()

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AcceptedSuggestionSpacingPolicy.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/AcceptedSuggestionSpacingPolicy.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.editor
+
+/**
+ * Spacing contract for accepted suggestions/corrections.
+ *
+ * Mainstream mobile keyboards usually distinguish between two cases:
+ * 1) accepting the current in-flight word at the cursor -> keep a pending separator so punctuation can follow cleanly
+ * 2) correcting a word that already has a literal separator after it -> reuse that separator instead of arming another one
+ */
+data class AcceptedSuggestionSpacingDecision(
+    val shouldActivatePhantomSpace: Boolean,
+    val cursorAdvanceAfterCommit: Int,
+)
+
+object AcceptedSuggestionSpacingPolicy {
+    fun forComposingReplacement(content: EditorContent): AcceptedSuggestionSpacingDecision {
+        return when (content.textAfterSelection.firstOrNull()) {
+            null -> AcceptedSuggestionSpacingDecision(
+                shouldActivatePhantomSpace = true,
+                cursorAdvanceAfterCommit = 0,
+            )
+            ' ' -> AcceptedSuggestionSpacingDecision(
+                shouldActivatePhantomSpace = false,
+                cursorAdvanceAfterCommit = 1,
+            )
+            else -> AcceptedSuggestionSpacingDecision(
+                shouldActivatePhantomSpace = false,
+                cursorAdvanceAfterCommit = 0,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/EditorInstance.kt
@@ -254,8 +254,13 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
         if (text.isEmpty() || activeInfo.isRawInputEditor) return false
         val content = activeContent
         return if (content.composing.isValid) {
-            phantomSpace.setActive(showComposingRegion = false, candidate = candidate)
-            super.finalizeComposingText(text)
+            val spacingDecision = AcceptedSuggestionSpacingPolicy.forComposingReplacement(content)
+            phantomSpace.setActive(
+                showComposingRegion = false,
+                candidate = candidate,
+                insertSeparator = spacingDecision.shouldActivatePhantomSpace,
+            )
+            super.finalizeComposingText(text, cursorAdvanceAfterText = spacingDecision.cursorAdvanceAfterCommit)
         } else {
             val isPhantomSpaceActive = phantomSpace.determine(text)
             phantomSpace.setActive(showComposingRegion = false, candidate = candidate)
@@ -614,9 +619,10 @@ class EditorInstance(context: Context) : AbstractEditorInstance(context) {
             showComposingRegion: Boolean,
             stayActiveNextUpdate: Boolean = true,
             candidate: SuggestionCandidate? = null,
+            insertSeparator: Boolean = true,
         ) {
             state.set(
-                F_IS_ACTIVE
+                (if (insertSeparator) F_IS_ACTIVE else 0)
                     or (if (showComposingRegion) F_SHOW_COMPOSING_REGION else 0)
                     or (if (stayActiveNextUpdate) F_STAY_ACTIVE_NEXT_UPDATE else 0)
             )

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/PendingSeparatorSuggestionContent.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/editor/PendingSeparatorSuggestionContent.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.editor
+
+/**
+ * Adapts editor content for suggestion refresh when the keyboard is carrying a pending separator
+ * (phantom space) after accepting a suggestion or gesture.
+ *
+ * In that state the visual editor still has the cursor directly after the committed word, but the
+ * next tap of a letter or punctuation symbol will behave as if a word boundary exists. For next-word
+ * prediction we therefore want the NLP layer to see a virtual boundary immediately.
+ */
+object PendingSeparatorSuggestionContent {
+    fun forRefresh(content: EditorContent, hasPendingSeparator: Boolean): EditorContent {
+        val selection = content.localSelection
+        if (!hasPendingSeparator || selection.isNotValid || !selection.isCursorMode) {
+            return content
+        }
+        val existingBoundaryChar = content.textBeforeSelection.lastOrNull()
+        if (existingBoundaryChar != null && (
+                existingBoundaryChar.isWhitespace() ||
+                    existingBoundaryChar in setOf('.', ',', ';', ':', '!', '?')
+                )
+        ) {
+            return content
+        }
+        if (content.textAfterSelection.firstOrNull()?.isWhitespace() == true) {
+            return content
+        }
+
+        val separator = " "
+        val newCursor = selection.start + separator.length
+        return EditorContent(
+            text = buildString(content.text.length + separator.length) {
+                append(content.textBeforeSelection)
+                append(separator)
+                append(content.textAfterSelection)
+            },
+            offset = content.offset,
+            localSelection = EditorRange.cursor(newCursor),
+            localComposing = EditorRange.Unspecified,
+            localCurrentWord = EditorRange.Unspecified,
+        )
+    }
+}

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTracker.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTracker.kt
@@ -58,6 +58,17 @@ internal class AutocorrectUndoTracker {
         )
     }
 
+    fun findBackspaceRestoreReplacement(content: EditorContent): AutocorrectUndoReplacement? {
+        if (content.selection.isSelectionMode) return null
+        val operation = pendingOperation ?: return null
+        val correctedTokenRange = findBackspaceRestoreRange(content, operation.correctedToken) ?: return null
+        return AutocorrectUndoReplacement(
+            range = correctedTokenRange,
+            originalToken = operation.originalToken,
+            candidate = operation.candidate,
+        )
+    }
+
     fun clearPending() {
         pendingOperation = null
     }
@@ -73,6 +84,21 @@ internal class AutocorrectUndoTracker {
         if (content.currentWord.isValid && content.currentWordText == correctedToken) {
             return content.currentWord
         }
+        return findTokenRangeBeforeCursor(content, correctedToken)
+    }
+
+    private fun findBackspaceRestoreRange(content: EditorContent, correctedToken: String): EditorRange? {
+        if (
+            content.currentWord.isValid &&
+            content.selection.end == content.currentWord.end &&
+            content.currentWordText == correctedToken
+        ) {
+            return content.currentWord
+        }
+        return findTokenRangeBeforeCursor(content, correctedToken)
+    }
+
+    private fun findTokenRangeBeforeCursor(content: EditorContent, correctedToken: String): EditorRange? {
         val beforeCursor = content.textBeforeSelection
         if (beforeCursor.isEmpty()) return null
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTracker.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTracker.kt
@@ -69,6 +69,11 @@ internal class AutocorrectUndoTracker {
         )
     }
 
+    fun originalTokenForCandidate(candidate: SuggestionCandidate?): String? {
+        val pending = pendingOperation ?: return null
+        return if (candidate == pending.candidate) pending.originalToken else null
+    }
+
     fun clearPending() {
         pendingOperation = null
     }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -437,17 +437,27 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
 
     private fun handleUndoLastAutocorrect(): Boolean {
         val undoReplacement = autocorrectUndoTracker.findUndoReplacement(editorInstance.activeContent) ?: return false
-        if (!editorInstance.setSelection(undoReplacement.range.start, undoReplacement.range.end)) return false
-        if (!editorInstance.commitText(undoReplacement.originalToken)) return false
+        return restoreTrackedAutocorrect(undoReplacement)
+    }
+
+    private fun handleBackspaceAutocorrectRestore(unit: OperationUnit): Boolean {
+        if (unit != OperationUnit.CHARACTERS) return false
+        val restoreReplacement = autocorrectUndoTracker.findBackspaceRestoreReplacement(editorInstance.activeContent) ?: return false
+        return restoreTrackedAutocorrect(restoreReplacement)
+    }
+
+    private fun restoreTrackedAutocorrect(replacement: AutocorrectUndoReplacement): Boolean {
+        if (!editorInstance.setSelection(replacement.range.start, replacement.range.end)) return false
+        if (!editorInstance.commitText(replacement.originalToken)) return false
         autocorrectUndoTracker.clearPending()
-        if (undoReplacement.candidate.isEligibleForAutoCommit) {
+        if (replacement.candidate.isEligibleForAutoCommit) {
             TypingSpeedMetrics.recordAutoCorrectUndone()
         }
-        undoReplacement.candidate.sourceProvider?.let { sourceProvider ->
+        replacement.candidate.sourceProvider?.let { sourceProvider ->
             scope.launch {
                 sourceProvider.notifySuggestionReverted(
                     subtype = subtypeManager.activeSubtype,
-                    candidate = undoReplacement.candidate,
+                    candidate = replacement.candidate,
                 )
             }
         }
@@ -465,6 +475,9 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             it.isManualSelectionMode = false
             it.isManualSelectionModeStart = false
             it.isManualSelectionModeEnd = false
+        }
+        if (handleBackspaceAutocorrectRestore(unit)) {
+            return
         }
         revertPreviouslyAcceptedCandidate()
         editorInstance.deleteBackwards(unit)

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -423,11 +423,13 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             if (candidateForRevert.isEligibleForAutoCommit) {
                 TypingSpeedMetrics.recordAutoCorrectUndone()
             }
+            val originalToken = autocorrectUndoTracker.originalTokenForCandidate(candidateForRevert)
             candidateForRevert.sourceProvider?.let { sourceProvider ->
                 scope.launch {
                     sourceProvider.notifySuggestionReverted(
                         subtype = subtypeManager.activeSubtype,
                         candidate = candidateForRevert,
+                        originalToken = originalToken,
                     )
                 }
             }
@@ -458,6 +460,7 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
                 sourceProvider.notifySuggestionReverted(
                     subtype = subtypeManager.activeSubtype,
                     candidate = replacement.candidate,
+                    originalToken = replacement.originalToken,
                 )
             }
         }

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/keyboard/KeyboardManager.kt
@@ -39,6 +39,7 @@ import dev.patrickgold.florisboard.ime.editor.FlorisEditorInfo
 import dev.patrickgold.florisboard.ime.editor.ImeOptions
 import dev.patrickgold.florisboard.ime.editor.InputAttributes
 import dev.patrickgold.florisboard.ime.editor.OperationUnit
+import dev.patrickgold.florisboard.ime.editor.PendingSeparatorSuggestionContent
 import dev.patrickgold.florisboard.ime.input.CapitalizationBehavior
 import dev.patrickgold.florisboard.ime.input.InputEventDispatcher
 import dev.patrickgold.florisboard.ime.input.InputKeyEventReceiver
@@ -235,7 +236,11 @@ class KeyboardManager(context: Context) : InputKeyEventReceiver {
             nlpManager.clearSuggestions()
             return
         }
-        nlpManager.suggest(subtypeManager.activeSubtype, content)
+        val suggestionContent = PendingSeparatorSuggestionContent.forRefresh(
+            content = content,
+            hasPendingSeparator = editorInstance.phantomSpace.isActive,
+        )
+        nlpManager.suggest(subtypeManager.activeSubtype, suggestionContent)
     }
 
     /**

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/media/emoji/EmojiSuggestionProvider.kt
@@ -100,7 +100,11 @@ class EmojiSuggestionProvider(private val context: Context) : SuggestionProvider
         EmojiHistoryHelper.markEmojiUsed(prefs, candidate.emoji)
     }
 
-    override suspend fun notifySuggestionReverted(subtype: Subtype, candidate: SuggestionCandidate) {
+    override suspend fun notifySuggestionReverted(
+        subtype: Subtype,
+        candidate: SuggestionCandidate,
+        originalToken: String?,
+    ) {
         // No-op
     }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpManager.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpManager.kt
@@ -418,7 +418,11 @@ class NlpManager(context: Context) {
             }
         }
 
-        override suspend fun notifySuggestionReverted(subtype: Subtype, candidate: SuggestionCandidate) {
+        override suspend fun notifySuggestionReverted(
+            subtype: Subtype,
+            candidate: SuggestionCandidate,
+            originalToken: String?,
+        ) {
             // Do nothing
         }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpProviders.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/NlpProviders.kt
@@ -153,14 +153,19 @@ interface SuggestionProvider : NlpProvider {
     suspend fun notifySuggestionAccepted(subtype: Subtype, candidate: SuggestionCandidate)
 
     /**
-     * Is called when a previously automatically accepted suggestion has been reverted by the user with backspace. This
-     * is purely a notification about an event and can safely be ignored if not needed.
+     * Is called when a previously automatically accepted suggestion has been reverted by the user with backspace or
+     * explicit undo. This is purely a notification about an event and can safely be ignored if not needed.
      *
      * @param subtype Information about the current subtype, primarily used for getting the primary and secondary
      *  language for correct dictionary selection.
      * @param candidate The exact suggestion candidate which has been reverted.
+     * @param originalToken The original token restored by the revert flow, if available.
      */
-    suspend fun notifySuggestionReverted(subtype: Subtype, candidate: SuggestionCandidate)
+    suspend fun notifySuggestionReverted(
+        subtype: Subtype,
+        candidate: SuggestionCandidate,
+        originalToken: String? = null,
+    )
 
     /**
      * Called if the user requests to prevent a certain suggested word from showing again. It is up to the actual
@@ -275,7 +280,11 @@ object FallbackNlpProvider : SpellingProvider, SuggestionProvider {
         // Do nothing
     }
 
-    override suspend fun notifySuggestionReverted(subtype: Subtype, candidate: SuggestionCandidate) {
+    override suspend fun notifySuggestionReverted(
+        subtype: Subtype,
+        candidate: SuggestionCandidate,
+        originalToken: String?,
+    ) {
         // Do nothing
     }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/han/HanShapeBasedLanguageProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/han/HanShapeBasedLanguageProvider.kt
@@ -210,7 +210,11 @@ class HanShapeBasedLanguageProvider(val context: Context) : SpellingProvider, Su
         flogDebug { candidate.toString() }
     }
 
-    override suspend fun notifySuggestionReverted(subtype: Subtype, candidate: SuggestionCandidate) {
+    override suspend fun notifySuggestionReverted(
+        subtype: Subtype,
+        candidate: SuggestionCandidate,
+        originalToken: String?,
+    ) {
         flogDebug { candidate.toString() }
     }
 

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/HighCertaintyAutocorrectPolicy.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/HighCertaintyAutocorrectPolicy.kt
@@ -34,9 +34,11 @@ internal class HighCertaintyAutocorrectPolicy(
         candidateConfidence: Double,
         runnerUpConfidence: Double?,
         hasExactInputMatch: Boolean,
+        isBlockedByUserPreference: Boolean = false,
     ): Boolean {
         if (!config.enabled) return false
         if (hasExactInputMatch) return false
+        if (isBlockedByUserPreference) return false
         if (normalizedInput.length < config.minInputLength) return false
         if (candidateWord == normalizedInput) return false
         if (candidateEditDistance < 1 || candidateEditDistance > config.maxAutoCorrectEditDistance) return false

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
@@ -340,6 +340,10 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
                         val autoCorrectPolicy = autocorrectPolicySnapshot.policy
                         val topCandidate = sortedCandidates.firstOrNull()
                         val runnerUpConfidence = sortedCandidates.getOrNull(1)?.confidence
+                        val isBlockedByUserPreference = isAutoCorrectBlockedByUserPreference(
+                            subtype = subtype,
+                            normalizedInput = normalizedInput,
+                        )
 
                         val sortedCandidateLocales = sortedCandidates.map { scoredCandidate ->
                             aggregatedCandidates[scoredCandidate.ranked.word]?.locale ?: primaryLocale
@@ -355,6 +359,7 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
                                 candidateConfidence = scoredCandidate.confidence,
                                 runnerUpConfidence = runnerUpConfidence,
                                 hasExactInputMatch = hasExactMatch,
+                                isBlockedByUserPreference = isBlockedByUserPreference,
                             )
                             WordSuggestionCandidate(
                                 text = suggestionText,
@@ -394,7 +399,11 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
         suggestionCache.withLock { it.clear() }
     }
 
-    override suspend fun notifySuggestionReverted(subtype: Subtype, candidate: SuggestionCandidate) {
+    override suspend fun notifySuggestionReverted(
+        subtype: Subtype,
+        candidate: SuggestionCandidate,
+        originalToken: String?,
+    ) {
         val resolvedLocale = resolveBestLocaleForWord(
             subtype = subtype,
             candidateWord = candidate.text.toString(),
@@ -403,6 +412,20 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
             language = resolvedLocale.language,
             candidateWord = candidate.text.toString(),
         )
+
+        val normalizedOriginalToken = originalToken
+            ?.let { normalizeInputWord(it, resolvedLocale.base) }
+            ?.takeIf { it.isNotBlank() }
+        if (candidate.isEligibleForAutoCommit && normalizedOriginalToken != null) {
+            val didUpdateNeverCorrectWords = NeverCorrectWordsHelper.suppressWord(
+                prefs = prefs,
+                normalizedWord = normalizedOriginalToken,
+                language = resolvedLocale.language,
+            )
+            if (didUpdateNeverCorrectWords) {
+                suggestionCache.withLock { it.clear() }
+            }
+        }
     }
 
     override suspend fun removeSuggestion(subtype: Subtype, candidate: SuggestionCandidate): Boolean {
@@ -1144,6 +1167,20 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
         return subtype.locales().firstOrNull { locale ->
             normalizeLanguageCode(locale.language) == normalizedLanguage
         }
+    }
+
+    private fun isAutoCorrectBlockedByUserPreference(
+        subtype: Subtype,
+        normalizedInput: String,
+    ): Boolean {
+        val languages = subtype.locales().mapTo(linkedSetOf()) { locale ->
+            normalizeLanguageCode(locale.language)
+        }
+        return NeverCorrectWordsHelper.isBlocked(
+            prefs = prefs,
+            normalizedWord = normalizedInput,
+            languages = languages,
+        )
     }
 
     private fun applyInputCase(rawInput: String, suggestion: String, locale: Locale): String {

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/NeverCorrectWords.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/NeverCorrectWords.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2026 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.nlp.latin
+
+import dev.patrickgold.florisboard.app.FlorisPreferenceModel
+import dev.patrickgold.florisboard.lib.devtools.flogError
+import dev.patrickgold.jetpref.datastore.model.PreferenceSerializer
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.util.Locale
+
+@Serializable
+data class NeverCorrectWordEntry(
+    val word: String,
+    val language: String?,
+)
+
+@Serializable
+data class NeverCorrectWords(
+    val entries: List<NeverCorrectWordEntry>,
+) {
+    fun contains(normalizedWord: String, languages: Set<String>): Boolean {
+        val canonicalWord = canonicalizeWord(normalizedWord)
+        if (canonicalWord.isBlank()) return false
+        val normalizedLanguages = languages.mapNotNullTo(linkedSetOf()) { language ->
+            canonicalizeLanguage(language)
+        }
+        return entries.any { entry ->
+            entry.word == canonicalWord && (
+                entry.language == null ||
+                    entry.language in normalizedLanguages
+                )
+        }
+    }
+
+    fun suppress(normalizedWord: String, language: String?): NeverCorrectWords {
+        val canonicalWord = canonicalizeWord(normalizedWord)
+        if (canonicalWord.isBlank()) return this
+        val canonicalLanguage = canonicalizeLanguage(language)
+        val updatedEntries = buildList {
+            add(NeverCorrectWordEntry(word = canonicalWord, language = canonicalLanguage))
+            entries
+                .asSequence()
+                .filterNot { entry -> entry.word == canonicalWord && entry.language == canonicalLanguage }
+                .take(MaxEntries - 1)
+                .forEach(::add)
+        }
+        return copy(entries = updatedEntries)
+    }
+
+    fun remove(normalizedWord: String, language: String?): NeverCorrectWords {
+        val canonicalWord = canonicalizeWord(normalizedWord)
+        val canonicalLanguage = canonicalizeLanguage(language)
+        return copy(entries = entries.filterNot { entry ->
+            entry.word == canonicalWord && entry.language == canonicalLanguage
+        })
+    }
+
+    object Serializer : PreferenceSerializer<NeverCorrectWords> {
+        override fun serialize(value: NeverCorrectWords): String {
+            return Json.encodeToString(value)
+        }
+
+        override fun deserialize(value: String): NeverCorrectWords {
+            return try {
+                Json.decodeFromString(value)
+            } catch (e: Exception) {
+                flogError { "Failed to deserialize NeverCorrectWords: $e" }
+                Empty
+            }
+        }
+    }
+
+    companion object {
+        val Empty = NeverCorrectWords(entries = emptyList())
+        const val MaxEntries = 256
+
+        private fun canonicalizeWord(word: String): String {
+            return word.trim().replace('’', '\'')
+        }
+
+        private fun canonicalizeLanguage(language: String?): String? {
+            return language
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+                ?.lowercase(Locale.ROOT)
+        }
+    }
+}
+
+object NeverCorrectWordsHelper {
+    private val guard = Mutex(locked = false)
+
+    suspend fun suppressWord(
+        prefs: FlorisPreferenceModel,
+        normalizedWord: String,
+        language: String?,
+    ): Boolean = guard.withLock {
+        val current = prefs.dictionary.neverCorrectWordsData.get()
+        val updated = current.suppress(normalizedWord = normalizedWord, language = language)
+        if (updated == current) {
+            false
+        } else {
+            prefs.dictionary.neverCorrectWordsData.set(updated)
+            true
+        }
+    }
+
+    fun isBlocked(
+        prefs: FlorisPreferenceModel,
+        normalizedWord: String,
+        languages: Set<String>,
+    ): Boolean {
+        return prefs.dictionary.neverCorrectWordsData.get().contains(
+            normalizedWord = normalizedWord,
+            languages = languages,
+        )
+    }
+}

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/ime/editor/AcceptedSuggestionSpacingPolicyTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/ime/editor/AcceptedSuggestionSpacingPolicyTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.editor
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class AcceptedSuggestionSpacingPolicyTest : FunSpec({
+    test("keeps phantom separator when accepted suggestion ends at the cursor") {
+        AcceptedSuggestionSpacingPolicy.forComposingReplacement(
+            contentAtCursorWithFollowingText("")
+        ) shouldBe AcceptedSuggestionSpacingDecision(
+            shouldActivatePhantomSpace = true,
+            cursorAdvanceAfterCommit = 0,
+        )
+    }
+
+    test("reuses an existing trailing space after correcting a committed word") {
+        AcceptedSuggestionSpacingPolicy.forComposingReplacement(
+            contentAtCursorWithFollowingText(" world")
+        ) shouldBe AcceptedSuggestionSpacingDecision(
+            shouldActivatePhantomSpace = false,
+            cursorAdvanceAfterCommit = 1,
+        )
+    }
+
+    test("does not arm phantom spacing when punctuation already follows the corrected word") {
+        AcceptedSuggestionSpacingPolicy.forComposingReplacement(
+            contentAtCursorWithFollowingText(", world")
+        ) shouldBe AcceptedSuggestionSpacingDecision(
+            shouldActivatePhantomSpace = false,
+            cursorAdvanceAfterCommit = 0,
+        )
+    }
+})
+
+private fun contentAtCursorWithFollowingText(textAfterSelection: String): EditorContent {
+    val textBeforeSelection = "helo"
+    val fullText = textBeforeSelection + textAfterSelection
+    return EditorContent(
+        text = fullText,
+        offset = 0,
+        localSelection = EditorRange.cursor(textBeforeSelection.length),
+        localComposing = EditorRange(0, textBeforeSelection.length),
+        localCurrentWord = EditorRange(0, textBeforeSelection.length),
+    )
+}

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/ime/editor/PendingSeparatorSuggestionContentTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/ime/editor/PendingSeparatorSuggestionContentTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2026 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.editor
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class PendingSeparatorSuggestionContentTest : FunSpec({
+    test("treats a pending separator after suggestion acceptance as an immediate next-word boundary") {
+        PendingSeparatorSuggestionContent.forRefresh(
+            content = acceptedWordContent(),
+            hasPendingSeparator = true,
+        ) shouldBe EditorContent(
+            text = "hello ",
+            offset = 0,
+            localSelection = EditorRange.cursor(6),
+            localComposing = EditorRange.Unspecified,
+            localCurrentWord = EditorRange.Unspecified,
+        )
+    }
+
+    test("leaves the literal editor content untouched when no separator is pending") {
+        val content = acceptedWordContent()
+        PendingSeparatorSuggestionContent.forRefresh(
+            content = content,
+            hasPendingSeparator = false,
+        ) shouldBe content
+    }
+
+    test("does not synthesize an extra separator when the cursor already sits at a real boundary") {
+        val content = EditorContent(
+            text = "hello world",
+            offset = 0,
+            localSelection = EditorRange.cursor(6),
+            localComposing = EditorRange.Unspecified,
+            localCurrentWord = EditorRange.Unspecified,
+        )
+        PendingSeparatorSuggestionContent.forRefresh(
+            content = content,
+            hasPendingSeparator = true,
+        ) shouldBe content
+    }
+})
+
+private fun acceptedWordContent(): EditorContent {
+    return EditorContent(
+        text = "hello",
+        offset = 0,
+        localSelection = EditorRange.cursor(5),
+        localComposing = EditorRange.Unspecified,
+        localCurrentWord = EditorRange(0, 5),
+    )
+}

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTrackerTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTrackerTest.kt
@@ -122,6 +122,15 @@ class AutocorrectUndoTrackerTest : FunSpec({
         tracker.findBackspaceRestoreReplacement(content).shouldBeNull()
     }
 
+    test("returns original token for matching candidate") {
+        val tracker = AutocorrectUndoTracker()
+        val correctedCandidate = WordSuggestionCandidate(text = "the", isEligibleForAutoCommit = true)
+        tracker.trackAutoCorrect(originalToken = "teh", correctedCandidate = correctedCandidate)
+
+        tracker.originalTokenForCandidate(correctedCandidate) shouldBe "teh"
+        tracker.originalTokenForCandidate(WordSuggestionCandidate(text = "tea", isEligibleForAutoCommit = true)).shouldBeNull()
+    }
+
     test("ignores invalid autocorrect history with blank or identical tokens") {
         val tracker = AutocorrectUndoTracker()
         tracker.trackAutoCorrect(

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTrackerTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/AutocorrectUndoTrackerTest.kt
@@ -70,6 +70,58 @@ class AutocorrectUndoTrackerTest : FunSpec({
         tracker.findUndoReplacement(contentAtCursor("I like tea ")).shouldBeNull()
     }
 
+    test("returns backspace restore replacement for corrected token before trailing space") {
+        val tracker = AutocorrectUndoTracker()
+        val correctedCandidate = WordSuggestionCandidate(text = "the", isEligibleForAutoCommit = true)
+        tracker.trackAutoCorrect(originalToken = "teh", correctedCandidate = correctedCandidate)
+
+        tracker.findBackspaceRestoreReplacement(contentAtCursor("I like the ")) shouldBe AutocorrectUndoReplacement(
+            range = EditorRange(start = 7, end = 10),
+            originalToken = "teh",
+            candidate = correctedCandidate,
+        )
+    }
+
+    test("returns backspace restore replacement when cursor is at end of corrected current word") {
+        val tracker = AutocorrectUndoTracker()
+        val correctedCandidate = WordSuggestionCandidate(text = "hello", isEligibleForAutoCommit = true)
+        tracker.trackAutoCorrect(originalToken = "helo", correctedCandidate = correctedCandidate)
+
+        tracker.findBackspaceRestoreReplacement(wordContent(text = "hello", cursor = 5)) shouldBe AutocorrectUndoReplacement(
+            range = EditorRange(0, 5),
+            originalToken = "helo",
+            candidate = correctedCandidate,
+        )
+    }
+
+    test("does not return backspace restore replacement when cursor moved inside corrected word") {
+        val tracker = AutocorrectUndoTracker()
+        tracker.trackAutoCorrect(
+            originalToken = "helo",
+            correctedCandidate = WordSuggestionCandidate(text = "hello", isEligibleForAutoCommit = true),
+        )
+
+        tracker.findBackspaceRestoreReplacement(wordContent(text = "hello", cursor = 3)).shouldBeNull()
+    }
+
+    test("does not return backspace restore replacement for active text selection") {
+        val tracker = AutocorrectUndoTracker()
+        tracker.trackAutoCorrect(
+            originalToken = "helo",
+            correctedCandidate = WordSuggestionCandidate(text = "hello", isEligibleForAutoCommit = true),
+        )
+
+        val content = EditorContent(
+            text = "hello world",
+            offset = 0,
+            localSelection = EditorRange(0, 5),
+            localComposing = EditorRange.Unspecified,
+            localCurrentWord = EditorRange(0, 5),
+        )
+
+        tracker.findBackspaceRestoreReplacement(content).shouldBeNull()
+    }
+
     test("ignores invalid autocorrect history with blank or identical tokens") {
         val tracker = AutocorrectUndoTracker()
         tracker.trackAutoCorrect(
@@ -93,5 +145,15 @@ private fun contentAtCursor(text: String): EditorContent {
         localSelection = EditorRange.cursor(text.length),
         localComposing = EditorRange.Unspecified,
         localCurrentWord = EditorRange.Unspecified,
+    )
+}
+
+private fun wordContent(text: String, cursor: Int): EditorContent {
+    return EditorContent(
+        text = text,
+        offset = 0,
+        localSelection = EditorRange.cursor(cursor),
+        localComposing = EditorRange.Unspecified,
+        localCurrentWord = EditorRange(0, text.length),
     )
 }

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/CharactersModifierLayoutTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/CharactersModifierLayoutTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.keyboard
+
+import dev.patrickgold.florisboard.ime.text.key.KeyCode
+import dev.patrickgold.florisboard.ime.text.key.KeyType
+import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
+import dev.patrickgold.florisboard.lib.io.loadJsonAsset
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class CharactersModifierLayoutTest {
+    @Test
+    fun `characters modifier layout exposes direct numeric advanced popup on symbols key`() {
+        val layoutPath = Paths.get(
+            "app",
+            "src",
+            "main",
+            "assets",
+            "ime",
+            "keyboard",
+            "org.florisboard.layouts",
+            "layouts",
+            "charactersMod",
+            "default.json",
+        )
+        val layoutJson = Files.readString(layoutPath)
+        val layout = loadJsonAsset<LayoutArrangement>(layoutJson).getOrThrow()
+
+        val viewSymbolsKey = layout
+            .last()
+            .first()
+            .let { it as TextKeyData }
+        val numericAdvancedPopup = viewSymbolsKey.popup?.main as? TextKeyData
+
+        assertNotNull(numericAdvancedPopup)
+        assertEquals(KeyCode.VIEW_NUMERIC_ADVANCED, numericAdvancedPopup?.code)
+        assertEquals(KeyType.SYSTEM_GUI, numericAdvancedPopup?.type)
+    }
+}

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/CharactersModifierLayoutTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/ime/keyboard/CharactersModifierLayoutTest.kt
@@ -20,16 +20,47 @@ import dev.patrickgold.florisboard.ime.text.key.KeyCode
 import dev.patrickgold.florisboard.ime.text.key.KeyType
 import dev.patrickgold.florisboard.ime.text.keyboard.TextKeyData
 import dev.patrickgold.florisboard.lib.io.loadJsonAsset
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Test
-import java.nio.file.Files
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.exists
+import kotlin.io.path.readText
 
-class CharactersModifierLayoutTest {
-    @Test
-    fun `characters modifier layout exposes direct numeric advanced popup on symbols key`() {
-        val layoutPath = Paths.get(
+class CharactersModifierLayoutTest : FunSpec({
+    test("characters modifier layout exposes direct numeric advanced popup on symbols key") {
+        val layoutPath = candidateLayoutPaths().firstOrNull(Path::exists)
+            ?: error("Unable to find characters modifier layout JSON from module or repo root")
+        val layoutJson = layoutPath.readText()
+        val layout = loadJsonAsset<LayoutArrangement>(layoutJson).getOrThrow()
+
+        val viewSymbolsKey = layout
+            .last()
+            .first()
+            .let { it as TextKeyData }
+        val numericAdvancedPopup = viewSymbolsKey.popup?.main as? TextKeyData
+
+        numericAdvancedPopup.shouldNotBeNull()
+        numericAdvancedPopup.code shouldBe KeyCode.VIEW_NUMERIC_ADVANCED
+        numericAdvancedPopup.type shouldBe KeyType.SYSTEM_GUI
+    }
+})
+
+private fun candidateLayoutPaths(): List<Path> {
+    return listOf(
+        Paths.get(
+            "src",
+            "main",
+            "assets",
+            "ime",
+            "keyboard",
+            "org.florisboard.layouts",
+            "layouts",
+            "charactersMod",
+            "default.json",
+        ),
+        Paths.get(
             "app",
             "src",
             "main",
@@ -40,18 +71,6 @@ class CharactersModifierLayoutTest {
             "layouts",
             "charactersMod",
             "default.json",
-        )
-        val layoutJson = Files.readString(layoutPath)
-        val layout = loadJsonAsset<LayoutArrangement>(layoutJson).getOrThrow()
-
-        val viewSymbolsKey = layout
-            .last()
-            .first()
-            .let { it as TextKeyData }
-        val numericAdvancedPopup = viewSymbolsKey.popup?.main as? TextKeyData
-
-        assertNotNull(numericAdvancedPopup)
-        assertEquals(KeyCode.VIEW_NUMERIC_ADVANCED, numericAdvancedPopup?.code)
-        assertEquals(KeyType.SYSTEM_GUI, numericAdvancedPopup?.type)
-    }
+        ),
+    )
 }

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/HighCertaintyAutocorrectPolicyTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/HighCertaintyAutocorrectPolicyTest.kt
@@ -87,6 +87,22 @@ class HighCertaintyAutocorrectPolicyTest : FunSpec({
         ).shouldBeFalse()
     }
 
+    test("auto-commit blocked when user preference suppresses the input") {
+        val policy = HighCertaintyAutocorrectPolicy(
+            HighCertaintyAutocorrectConfig(minInputLength = 3)
+        )
+
+        policy.shouldAutoCommit(
+            normalizedInput = "teh",
+            candidateWord = "the",
+            candidateEditDistance = 1,
+            candidateConfidence = 0.97,
+            runnerUpConfidence = 0.10,
+            hasExactInputMatch = false,
+            isBlockedByUserPreference = true,
+        ).shouldBeFalse()
+    }
+
     test("auto-commit blocked for short input and larger edit distance") {
         val policy = HighCertaintyAutocorrectPolicy(
             HighCertaintyAutocorrectConfig(minInputLength = 4, maxAutoCorrectEditDistance = 1)

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/NeverCorrectWordsTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/NeverCorrectWordsTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 The FlorisBoard Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.patrickgold.florisboard.ime.nlp.latin
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+
+class NeverCorrectWordsTest : FunSpec({
+    test("suppression entries are deduplicated and moved to the front") {
+        val words = NeverCorrectWords.Empty
+            .suppress(normalizedWord = "teh", language = "en")
+            .suppress(normalizedWord = "spelng", language = "en")
+            .suppress(normalizedWord = "teh", language = "en")
+
+        words.entries.shouldContainExactly(
+            NeverCorrectWordEntry(word = "teh", language = "en"),
+            NeverCorrectWordEntry(word = "spelng", language = "en"),
+        )
+    }
+
+    test("contains only matches the scoped language entry") {
+        val words = NeverCorrectWords.Empty
+            .suppress(normalizedWord = "teh", language = "en")
+            .suppress(normalizedWord = "teh", language = "nl")
+
+        words.contains(normalizedWord = "teh", languages = setOf("en")) shouldBe true
+        words.contains(normalizedWord = "teh", languages = setOf("nl")) shouldBe true
+        words.contains(normalizedWord = "teh", languages = setOf("de")) shouldBe false
+    }
+
+    test("remove deletes only the targeted scoped entry") {
+        val words = NeverCorrectWords.Empty
+            .suppress(normalizedWord = "teh", language = "en")
+            .suppress(normalizedWord = "teh", language = "nl")
+            .remove(normalizedWord = "teh", language = "en")
+
+        words.entries.shouldContainExactly(
+            NeverCorrectWordEntry(word = "teh", language = "nl"),
+        )
+    }
+})


### PR DESCRIPTION
## Summary
- add primary-source citations to the predictive-typing-quality-trust Delano planning docs
- implement the first dependency-safe T-009 execution slice by adding a direct numeric-advanced shortcut to the base `?123` key
- add T-009 execution/update artifacts and fix older Delano path-leakage verification strings so validation passes cleanly

## Why this next
`./.agents/scripts/pm/next.sh --all` identified `typing-speed-core` T-009 as the next dependency-safe implementation task, while `predictive-typing-quality-trust` stays the planning and quality-trust layer.

## Implementation details
- `charactersMod/default.json`: add a `VIEW_NUMERIC_ADVANCED` popup to the `VIEW_SYMBOLS` key so users can jump straight from the base characters row into the full numeric/symbol layer with one less interaction
- `CharactersModifierLayoutTest`: lock the new shortcut wiring with a focused layout-parsing test
- `T-009` task + update artifact: document the first execution slice, validation evidence, and the local Gradle blocker honestly

## Validation
- `bash .claude/scripts/pm/validate.sh` ✅
- targeted JSON structural assertion for the new `?123 -> numeric advanced` popup ✅
- local Gradle compile/test/build in the Codex sandbox ❌ blocked before task execution by `java.net.SocketException: Operation not permitted (Socket creation failed)` from `NetworkInterface.getNetworkInterfaces()` inside Gradle's file-lock listener startup

## Build path
Because the local sandbox cannot start Gradle reliably, this PR is the build path for the next APK/artifact run.
